### PR TITLE
feat(hooks): make startup rollback shared across run and serve

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
   disable:
     - contextcheck
     - depguard
+    - err113
     - exhaustruct
     - funcorder
     - gochecknoglobals

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Primary public API lives in `signal.go`:
 ## Layout
 
 - `signal.go`: library implementation
+- `internal/test/`: shared test helpers for startup rollback scenarios
 - `cmd/main.go`: runnable example used by `make run`
 - `run_test.go`: tests for `Run`
 - `serve_test.go`: tests for `Serve` and `Timer`
@@ -125,14 +126,17 @@ stored under `test/reports/`.
 ### Run semantics
 
 - `Lifecycle.Run` runs start hooks in registration order
+- it attempts all start hooks and collects startup errors with `errors.Join`
+- if startup fails, it rolls back by running stop hooks only for successfully started hooks using the caller context
 - if all start hooks succeed, it runs the supplied handler
-- stop hooks run only if the handler returns `nil`
-- start stops on the first error
+- after successful startup, stop hooks run even if the handler returns an error
 - stop collects all hook errors with `errors.Join`
 
 ### Serve semantics
 
 - `Lifecycle.Serve` resets and ignores existing `SIGINT` and `SIGTERM` handlers
+- it attempts all start hooks and collects startup errors with `errors.Join`
+- if startup fails, it rolls back successfully started hooks with a fresh background context bounded by the lifecycle timeout and returns without entering the wait loop
 - it creates a `signal.NotifyContext` and blocks until shutdown is requested
 - shutdown can come from parent context cancellation, an OS signal, or `signal.Shutdown()`
 - stop hooks run with a fresh background context bounded by the lifecycle timeout

--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ signal.Register(signal.Hook{
 
 `Run` executes all start hooks, then your handler, then all stop hooks.
 
-- If a start hook fails, `Run` returns immediately.
-- If your handler fails, `Run` returns that error and does not run stop hooks.
-- Stop-hook errors are combined with `errors.Join`.
+- `Run` attempts every start hook, even if an earlier one fails.
+- If startup fails, `Run` rolls back by calling stop hooks for the hooks that
+  started successfully.
+- After successful startup, `Run` always runs stop hooks, even if the handler fails.
+- Startup, handler, and stop-hook errors are combined with `errors.Join`.
 
 ```go
 import (
@@ -83,6 +85,8 @@ err := signal.Run(context.Background(), func(context.Context) error {
 shutdown is requested.
 
 - It runs start hooks first.
+- If startup fails, it still attempts the remaining start hooks and then rolls
+  back successfully started hooks.
 - It waits for `SIGINT` or `SIGTERM`, or for the parent context to be canceled.
 - It then runs stop hooks with a fresh background context bounded by the
   lifecycle timeout.

--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -1,0 +1,5 @@
+// Package main provides the runnable example used by `make run`.
+//
+// The command demonstrates the library's startup, timer, and termination flows
+// against the `github.com/alexfalkowski/go-signal` package.
+package main

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,12 @@
+// Package signal provides a small lifecycle for coordinating application
+// startup and shutdown work around process signals.
+//
+// A [Lifecycle] runs registered hooks in three phases:
+//
+//   - start, by calling each hook's [Hook.OnStart]
+//   - run, by executing user code through [Run] or waiting for shutdown through [Serve]
+//   - stop, by calling each hook's [Hook.OnStop]
+//
+// The package-level helpers operate on a process-wide default lifecycle that is
+// initialized with a 30-second stop timeout.
+package signal

--- a/internal/test/doc.go
+++ b/internal/test/doc.go
@@ -1,0 +1,5 @@
+// Package test provides shared fixtures for the repository's black-box tests.
+//
+// These helpers are used by tests in external packages such as `signal_test` to
+// share setup code without exposing test-only APIs from the main package.
+package test

--- a/internal/test/rollback.go
+++ b/internal/test/rollback.go
@@ -1,0 +1,74 @@
+package test
+
+import (
+	"context"
+
+	"github.com/alexfalkowski/go-signal"
+)
+
+// RegisterRollbackHooks registers a fixed set of lifecycle hooks that exercise
+// startup rollback behavior and returns the event log used by those hooks.
+//
+// The registered hooks always attempt startup in this order:
+//
+//   - hook 1 starts successfully and stops successfully
+//   - hook 2 fails during start with startErr1
+//   - hook 3 starts successfully and fails during stop with stopErr
+//   - hook 4 fails during start with startErr2
+//
+// Each hook appends its start and stop activity to the returned slice so callers
+// can assert the exact execution order. The returned pointer remains valid for
+// the lifetime of the test because the closures capture the underlying slice.
+//
+// This helper is intended for tests that need to verify that startup:
+//
+//   - attempts all registered start hooks
+//   - rolls back only successfully started hooks
+//   - preserves registration order during rollback
+//   - joins startup and rollback errors
+func RegisterRollbackHooks(startErr1, startErr2, stopErr error) *[]string {
+	events := make([]string, 0)
+
+	signal.Register(signal.Hook{
+		OnStart: func(context.Context) error {
+			events = append(events, "start:1")
+			return nil
+		},
+		OnStop: func(context.Context) error {
+			events = append(events, "stop:1")
+			return nil
+		},
+	})
+	signal.Register(signal.Hook{
+		OnStart: func(context.Context) error {
+			events = append(events, "start:2")
+			return startErr1
+		},
+		OnStop: func(context.Context) error {
+			events = append(events, "stop:2")
+			return nil
+		},
+	})
+	signal.Register(signal.Hook{
+		OnStart: func(context.Context) error {
+			events = append(events, "start:3")
+			return nil
+		},
+		OnStop: func(context.Context) error {
+			events = append(events, "stop:3")
+			return stopErr
+		},
+	})
+	signal.Register(signal.Hook{
+		OnStart: func(context.Context) error {
+			events = append(events, "start:4")
+			return startErr2
+		},
+		OnStop: func(context.Context) error {
+			events = append(events, "stop:4")
+			return nil
+		},
+	})
+
+	return &events
+}

--- a/run_test.go
+++ b/run_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/alexfalkowski/go-signal"
+	"github.com/alexfalkowski/go-signal/internal/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,11 +24,20 @@ func TestRunEmpty(t *testing.T) {
 
 func TestRunError(t *testing.T) {
 	signal.SetDefault(signal.NewLifeCycle(time.Minute))
-	signal.Register(signal.Hook{})
+	stopped := false
+	signal.Register(signal.Hook{
+		OnStop: func(context.Context) error {
+			stopped = true
+			return nil
+		},
+	})
 
-	require.Error(t, signal.Run(t.Context(), func(context.Context) error {
+	err := signal.Run(t.Context(), func(context.Context) error {
 		return errRun
-	}))
+	})
+
+	require.ErrorIs(t, err, errRun)
+	require.True(t, stopped)
 }
 
 func TestRunStartError(t *testing.T) {
@@ -43,6 +53,34 @@ func TestRunStartError(t *testing.T) {
 	}))
 }
 
+func TestRunStartRollback(t *testing.T) {
+	startErr1 := errors.New("signal: run start error 1")
+	startErr2 := errors.New("signal: run start error 2")
+	stopErr := errors.New("signal: run stop error")
+	handlerCalled := false
+
+	signal.SetDefault(signal.NewLifeCycle(time.Minute))
+	events := test.RegisterRollbackHooks(startErr1, startErr2, stopErr)
+
+	err := signal.Run(t.Context(), func(context.Context) error {
+		handlerCalled = true
+		return nil
+	})
+
+	require.ErrorIs(t, err, startErr1)
+	require.ErrorIs(t, err, startErr2)
+	require.ErrorIs(t, err, stopErr)
+	require.False(t, handlerCalled)
+	require.Equal(t, []string{
+		"start:1",
+		"start:2",
+		"start:3",
+		"start:4",
+		"stop:1",
+		"stop:3",
+	}, *events)
+}
+
 func TestRunStopError(t *testing.T) {
 	signal.SetDefault(signal.NewLifeCycle(time.Minute))
 	signal.Register(signal.Hook{
@@ -54,4 +92,22 @@ func TestRunStopError(t *testing.T) {
 	require.Error(t, signal.Run(t.Context(), func(context.Context) error {
 		return nil
 	}))
+}
+
+func TestRunHandlerAndStopError(t *testing.T) {
+	stopErr := errors.New("signal: stop error")
+
+	signal.SetDefault(signal.NewLifeCycle(time.Minute))
+	signal.Register(signal.Hook{
+		OnStop: func(context.Context) error {
+			return stopErr
+		},
+	})
+
+	err := signal.Run(t.Context(), func(context.Context) error {
+		return errRun
+	})
+
+	require.ErrorIs(t, err, errRun)
+	require.ErrorIs(t, err, stopErr)
 }

--- a/serve_test.go
+++ b/serve_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/alexfalkowski/go-signal"
+	"github.com/alexfalkowski/go-signal/internal/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,12 +33,42 @@ func TestServeStartError(t *testing.T) {
 		},
 	})
 
+	require.Error(t, signal.Serve(t.Context()))
+}
+
+func TestServeStartRollback(t *testing.T) {
+	startErr1 := errors.New("signal: serve start error 1")
+	startErr2 := errors.New("signal: serve start error 2")
+	stopErr := errors.New("signal: serve stop error")
+
+	signal.SetDefault(signal.NewLifeCycle(time.Minute))
+	events := test.RegisterRollbackHooks(startErr1, startErr2, stopErr)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
 	go func() {
-		time.Sleep(time.Second)
-		_ = signal.Shutdown()
+		done <- signal.Serve(ctx)
 	}()
 
-	require.Error(t, signal.Serve(t.Context()))
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, startErr1)
+		require.ErrorIs(t, err, startErr2)
+		require.ErrorIs(t, err, stopErr)
+	case <-time.After(100 * time.Millisecond):
+		require.Fail(t, "Serve blocked after startup failure")
+	}
+
+	require.Equal(t, []string{
+		"start:1",
+		"start:2",
+		"start:3",
+		"start:4",
+		"stop:1",
+		"stop:3",
+	}, *events)
 }
 
 func TestServeGoError(t *testing.T) {

--- a/signal.go
+++ b/signal.go
@@ -1,14 +1,3 @@
-// Package signal provides a small lifecycle for coordinating application
-// startup and shutdown work around process signals.
-//
-// A [Lifecycle] runs registered hooks in three phases:
-//
-//   - start, by calling each hook's [Hook.OnStart]
-//   - run, by executing user code through [Run] or waiting for shutdown through [Serve]
-//   - stop, by calling each hook's [Hook.OnStop]
-//
-// The package-level helpers operate on a process-wide default lifecycle that is
-// initialized with a 30-second stop timeout.
 package signal
 
 import (
@@ -220,32 +209,32 @@ func (l *Lifecycle) Register(h Hook) {
 
 // Run executes the lifecycle against ctx.
 //
-// Run calls each registered start hook in registration order. If all start hooks
-// succeed, it calls h. If h also succeeds, Run then calls each registered stop
-// hook with the same ctx.
+// Run calls each registered start hook in registration order. If any start hook
+// fails, Run still attempts the remaining start hooks, then rolls back by
+// calling stop hooks for the hooks that started successfully using the same ctx.
+// If startup succeeds, it calls h, then calls each registered stop hook with
+// the same ctx.
 //
-// Run stops immediately on the first start-hook error or on h returning an
-// error. Stop hooks are only run after h returns nil. Stop-hook errors are
-// combined with [errors.Join].
+// Startup, handler, and stop-hook errors are combined with [errors.Join].
 func (l *Lifecycle) Run(ctx context.Context, h Handler) error {
-	if err := l.start(ctx); err != nil {
-		return err
+	started, err := l.start(ctx)
+	if err != nil {
+		return errors.Join(err, l.stop(ctx, started))
 	}
 
-	if err := h(ctx); err != nil {
-		return err
-	}
-
-	return l.stop(ctx)
+	return errors.Join(h(ctx), l.stop(ctx, l.hooks))
 }
 
 // Serve runs the lifecycle until shutdown is requested.
 //
 // Serve resets any existing SIGINT and SIGTERM handlers, registers its own
-// notification context, runs all start hooks with that context, then blocks until
-// the notification context is done. Shutdown can happen because the parent ctx is
-// cancelled, because the process receives SIGINT or SIGTERM, or because
-// [Shutdown] delivers an interrupt to the current process.
+// notification context, runs all start hooks with that context, then blocks
+// until the notification context is done. If startup fails, Serve still
+// attempts the remaining start hooks, then rolls back successfully started hooks
+// with a fresh background context bounded by the lifecycle timeout. Shutdown can
+// happen because the parent ctx is cancelled, because the process receives
+// SIGINT or SIGTERM, or because [Shutdown] delivers an interrupt to the current
+// process.
 //
 // After shutdown is requested, Serve runs stop hooks with a fresh background
 // context bounded by the lifecycle timeout configured by [NewLifeCycle].
@@ -262,8 +251,12 @@ func (l *Lifecycle) Serve(ctx context.Context) error {
 	notifyCtx, stop := signal.NotifyContext(ctx, signals...)
 	defer stop()
 
-	if err := l.start(notifyCtx); err != nil {
-		return err
+	started, err := l.start(notifyCtx)
+	if err != nil {
+		stopCtx, cancel := context.WithTimeout(context.Background(), l.timeout)
+		defer cancel()
+
+		return errors.Join(err, l.stop(stopCtx, started))
 	}
 
 	<-notifyCtx.Done()
@@ -272,7 +265,7 @@ func (l *Lifecycle) Serve(ctx context.Context) error {
 	stopCtx, cancel := context.WithTimeout(context.Background(), l.timeout)
 	defer cancel()
 
-	return l.stop(stopCtx)
+	return l.stop(stopCtx, l.hooks)
 }
 
 // Shutdown sends an [os.Interrupt] signal to the current process.
@@ -284,18 +277,25 @@ func (l *Lifecycle) Shutdown() error {
 	return process.Signal(os.Interrupt)
 }
 
-func (l *Lifecycle) start(ctx context.Context) error {
+func (l *Lifecycle) start(ctx context.Context) ([]Hook, error) {
+	started := make([]Hook, 0, len(l.hooks))
+	errs := make([]error, 0)
+
 	for _, hook := range l.hooks {
 		if err := hook.Start(ctx); err != nil {
-			return err
+			errs = append(errs, err)
+			continue
 		}
+
+		started = append(started, hook)
 	}
-	return nil
+
+	return started, errors.Join(errs...)
 }
 
-func (l *Lifecycle) stop(ctx context.Context) error {
+func (l *Lifecycle) stop(ctx context.Context, hooks []Hook) error {
 	errs := make([]error, 0)
-	for _, hook := range l.hooks {
+	for _, hook := range hooks {
 		if err := hook.Stop(ctx); err != nil {
 			errs = append(errs, err)
 		}


### PR DESCRIPTION
## What

Updated the lifecycle flow so `Run` and `Serve` share the same startup behavior when hooks fail during startup.

- Attempt all registered `OnStart` hooks instead of failing fast on the first error
- Roll back by calling `OnStop` only for hooks that started successfully
- Join startup and rollback errors into the returned error
- Update `Run` so after successful startup it always executes stop hooks, even when the handler returns an error
- Join handler and stop-hook errors in `Run`
- Keep existing `Serve` shutdown behavior unchanged
- Update README and AGENTS docs to describe the new semantics
- Add tests covering rollback behavior and handler-error shutdown behavior

## Why

Startup should behave more safely when multiple dependencies are involved, and shutdown should still happen when the main handler fails.

Previously, a single start failure stopped execution immediately and could leave already-started hooks running. Also, a handler failure in `Run` skipped the stop phase entirely. This change makes lifecycle behavior more predictable by attempting all startup work, rolling back anything that started successfully when startup fails, and always running cleanup after a successful startup.

## Testing

```sh
env GOCACHE=/tmp/go-build go test ./...
```

Added or updated coverage for:

- all start hooks being attempted even after earlier failures
- rollback only stopping successfully started hooks
- rollback error aggregation with startup errors
- `Run` not calling the handler when startup fails
- `Run` still calling stop hooks when the handler returns an error
- `Run` joining handler and stop-hook errors
- `Serve` returning immediately instead of entering the wait loop when startup fails