### PR TITLE
fix(lifecycle): shutdown order to use lifo

### DIFF
--- a/internal/test/rollback.go
+++ b/internal/test/rollback.go
@@ -24,7 +24,7 @@ import (
 //
 //   - attempts all registered start hooks
 //   - rolls back only successfully started hooks
-//   - preserves registration order during rollback
+//   - preserves reverse registration order during rollback
 //   - joins startup and rollback errors
 func RegisterRollbackHooks(startErr1, startErr2, stopErr error) *[]string {
 	events := make([]string, 0)

--- a/run_test.go
+++ b/run_test.go
@@ -76,9 +76,28 @@ func TestRunStartRollback(t *testing.T) {
 		"start:2",
 		"start:3",
 		"start:4",
-		"stop:1",
 		"stop:3",
+		"stop:1",
 	}, *events)
+}
+
+func TestRunStopOrder(t *testing.T) {
+	events := make([]string, 0, 3)
+
+	signal.SetDefault(signal.NewLifeCycle(time.Minute))
+	for _, event := range []string{"stop:1", "stop:2", "stop:3"} {
+		signal.Register(signal.Hook{
+			OnStop: func(context.Context) error {
+				events = append(events, event)
+				return nil
+			},
+		})
+	}
+
+	require.NoError(t, signal.Run(t.Context(), func(context.Context) error {
+		return nil
+	}))
+	require.Equal(t, []string{"stop:3", "stop:2", "stop:1"}, events)
 }
 
 func TestRunStopError(t *testing.T) {

--- a/serve_test.go
+++ b/serve_test.go
@@ -66,9 +66,32 @@ func TestServeStartRollback(t *testing.T) {
 		"start:2",
 		"start:3",
 		"start:4",
-		"stop:1",
 		"stop:3",
+		"stop:1",
 	}, *events)
+}
+
+func TestServeStopOrder(t *testing.T) {
+	events := make([]string, 0, 3)
+
+	signal.SetDefault(signal.NewLifeCycle(time.Minute))
+	for _, event := range []string{"stop:1", "stop:2", "stop:3"} {
+		signal.Register(signal.Hook{
+			OnStop: func(context.Context) error {
+				events = append(events, event)
+				return nil
+			},
+		})
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	require.NoError(t, signal.Serve(ctx))
+	require.Equal(t, []string{"stop:3", "stop:2", "stop:1"}, events)
 }
 
 func TestServeGoError(t *testing.T) {

--- a/signal.go
+++ b/signal.go
@@ -211,9 +211,10 @@ func (l *Lifecycle) Register(h Hook) {
 //
 // Run calls each registered start hook in registration order. If any start hook
 // fails, Run still attempts the remaining start hooks, then rolls back by
-// calling stop hooks for the hooks that started successfully using the same ctx.
-// If startup succeeds, it calls h, then calls each registered stop hook with
-// the same ctx.
+// calling stop hooks for the hooks that started successfully in reverse
+// registration order using the same ctx. If startup succeeds, it calls h, then
+// calls each registered stop hook in reverse registration order with the same
+// ctx.
 //
 // Startup, handler, and stop-hook errors are combined with [errors.Join].
 func (l *Lifecycle) Run(ctx context.Context, h Handler) error {
@@ -231,13 +232,14 @@ func (l *Lifecycle) Run(ctx context.Context, h Handler) error {
 // notification context, runs all start hooks with that context, then blocks
 // until the notification context is done. If startup fails, Serve still
 // attempts the remaining start hooks, then rolls back successfully started hooks
-// with a fresh background context bounded by the lifecycle timeout. Shutdown can
-// happen because the parent ctx is cancelled, because the process receives
-// SIGINT or SIGTERM, or because [Shutdown] delivers an interrupt to the current
-// process.
+// in reverse registration order with a fresh background context bounded by the
+// lifecycle timeout. Shutdown can happen because the parent ctx is cancelled,
+// because the process receives SIGINT or SIGTERM, or because [Shutdown]
+// delivers an interrupt to the current process.
 //
-// After shutdown is requested, Serve runs stop hooks with a fresh background
-// context bounded by the lifecycle timeout configured by [NewLifeCycle].
+// After shutdown is requested, Serve runs stop hooks in reverse registration
+// order with a fresh background context bounded by the lifecycle timeout
+// configured by [NewLifeCycle].
 //
 // Note: Serve takes ownership of SIGINT and SIGTERM for the process while it is
 // active. Other handlers for those signals will not run during that time.
@@ -295,8 +297,8 @@ func (l *Lifecycle) start(ctx context.Context) ([]Hook, error) {
 
 func (l *Lifecycle) stop(ctx context.Context, hooks []Hook) error {
 	errs := make([]error, 0)
-	for _, hook := range hooks {
-		if err := hook.Stop(ctx); err != nil {
+	for i := len(hooks) - 1; i >= 0; i-- {
+		if err := hooks[i].Stop(ctx); err != nil {
 			errs = append(errs, err)
 		}
 	}


### PR DESCRIPTION
## What

- changed lifecycle shutdown and rollback to run hooks in reverse registration order
- updated the inline lifecycle documentation to describe LIFO stop behavior
- added test coverage for both `Run` and `Serve` to lock in reverse-order shutdown

## Why

Stopping hooks in registration order can tear down dependencies too early. Running stop hooks in reverse registration order matches typical lifecycle semantics and makes rollback/shutdown safer when later hooks depend on earlier ones.

## Testing

```sh
env GOCACHE=/tmp/go-build go test ./...
```