### PR TITLE
feat(run): cleanup to use fresh shutdown context

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ signal.Register(signal.Hook{
 - `Run` attempts every start hook, even if an earlier one fails.
 - If startup fails, `Run` rolls back by calling stop hooks for the hooks that
   started successfully.
-- After successful startup, `Run` always runs stop hooks, even if the handler fails.
+- `Run` executes rollback and stop hooks with a fresh background context bounded
+  by the lifecycle timeout.
+- After successful startup, `Run` always runs stop hooks, even if the handler
+  fails.
 - Startup, handler, and stop-hook errors are combined with `errors.Join`.
 
 ```go

--- a/run_test.go
+++ b/run_test.go
@@ -81,6 +81,36 @@ func TestRunStartRollback(t *testing.T) {
 	}, *events)
 }
 
+func TestRunStartRollbackFreshStopContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	stopped := false
+
+	signal.SetDefault(signal.NewLifeCycle(time.Minute))
+	signal.Register(signal.Hook{
+		OnStart: func(context.Context) error {
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			stopped = true
+			return ctx.Err()
+		},
+	})
+	signal.Register(signal.Hook{
+		OnStart: func(context.Context) error {
+			cancel()
+			return errRun
+		},
+	})
+
+	err := signal.Run(ctx, func(context.Context) error {
+		return nil
+	})
+
+	require.ErrorIs(t, err, errRun)
+	require.NotErrorIs(t, err, context.Canceled)
+	require.True(t, stopped)
+}
+
 func TestRunStopOrder(t *testing.T) {
 	events := make([]string, 0, 3)
 
@@ -98,6 +128,22 @@ func TestRunStopOrder(t *testing.T) {
 		return nil
 	}))
 	require.Equal(t, []string{"stop:3", "stop:2", "stop:1"}, events)
+}
+
+func TestRunStopFreshContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	signal.SetDefault(signal.NewLifeCycle(time.Minute))
+	signal.Register(signal.Hook{
+		OnStop: func(ctx context.Context) error {
+			return ctx.Err()
+		},
+	})
+
+	require.NoError(t, signal.Run(ctx, func(context.Context) error {
+		cancel()
+		return nil
+	}))
 }
 
 func TestRunStopError(t *testing.T) {

--- a/signal.go
+++ b/signal.go
@@ -183,8 +183,8 @@ func Shutdown() error {
 // NewLifeCycle returns a new empty [Lifecycle] configured with the given stop
 // timeout.
 //
-// The stop timeout is used by [Lifecycle.Serve] when running stop hooks after a
-// shutdown signal is received.
+// The stop timeout is used by [Lifecycle.Run] and [Lifecycle.Serve] when
+// running stop hooks during rollback and shutdown.
 func NewLifeCycle(timeout time.Duration) *Lifecycle {
 	return &Lifecycle{hooks: make([]Hook, 0), timeout: timeout}
 }
@@ -212,18 +212,27 @@ func (l *Lifecycle) Register(h Hook) {
 // Run calls each registered start hook in registration order. If any start hook
 // fails, Run still attempts the remaining start hooks, then rolls back by
 // calling stop hooks for the hooks that started successfully in reverse
-// registration order using the same ctx. If startup succeeds, it calls h, then
-// calls each registered stop hook in reverse registration order with the same
-// ctx.
+// registration order with a fresh background context bounded by the lifecycle
+// timeout. If startup succeeds, it calls h, then calls each registered stop
+// hook in reverse registration order with the same kind of fresh shutdown
+// context.
 //
 // Startup, handler, and stop-hook errors are combined with [errors.Join].
 func (l *Lifecycle) Run(ctx context.Context, h Handler) error {
 	started, err := l.start(ctx)
 	if err != nil {
-		return errors.Join(err, l.stop(ctx, started))
+		stopCtx, cancel := l.stopContext()
+		defer cancel()
+
+		return errors.Join(err, l.stop(stopCtx, started))
 	}
 
-	return errors.Join(h(ctx), l.stop(ctx, l.hooks))
+	handlerErr := h(ctx)
+
+	stopCtx, cancel := l.stopContext()
+	defer cancel()
+
+	return errors.Join(handlerErr, l.stop(stopCtx, l.hooks))
 }
 
 // Serve runs the lifecycle until shutdown is requested.
@@ -255,7 +264,7 @@ func (l *Lifecycle) Serve(ctx context.Context) error {
 
 	started, err := l.start(notifyCtx)
 	if err != nil {
-		stopCtx, cancel := context.WithTimeout(context.Background(), l.timeout)
+		stopCtx, cancel := l.stopContext()
 		defer cancel()
 
 		return errors.Join(err, l.stop(stopCtx, started))
@@ -264,7 +273,7 @@ func (l *Lifecycle) Serve(ctx context.Context) error {
 	<-notifyCtx.Done()
 	stop()
 
-	stopCtx, cancel := context.WithTimeout(context.Background(), l.timeout)
+	stopCtx, cancel := l.stopContext()
 	defer cancel()
 
 	return l.stop(stopCtx, l.hooks)
@@ -293,6 +302,10 @@ func (l *Lifecycle) start(ctx context.Context) ([]Hook, error) {
 	}
 
 	return started, errors.Join(errs...)
+}
+
+func (l *Lifecycle) stopContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), l.timeout)
 }
 
 func (l *Lifecycle) stop(ctx context.Context, hooks []Hook) error {


### PR DESCRIPTION
## What

- updated `Run` to execute rollback and final stop hooks with a fresh timeout-bound shutdown context
- extracted shared stop-context creation so `Run` and `Serve` use the same cleanup behavior
- added regression tests for canceled startup rollback and canceled handler shutdown
- refreshed the `Run` documentation in code and README

## Why

`Run` previously passed the caller context into cleanup hooks, which meant rollback or shutdown could inherit an already-canceled context and fail immediately. Using a fresh timeout-bound context makes `Run` cleanup reliable and consistent with `Serve`.

## Testing

```sh
env GOCACHE=/tmp/go-build go test ./...
```