### PR TITLE
fix(hooks): timer to stop hooks on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ err := signal.Go(context.Background(), 5*time.Second, func(context.Context) erro
 
 - call `hook.OnStart` once
 - call `hook.OnTick` on each interval
-- when the parent context is canceled, call `hook.OnStop` with a fresh
-  background context bounded by the supplied timeout
+- when the parent context is canceled or a timer hook returns an error, call
+  `hook.OnStop` with a fresh background context bounded by the supplied timeout
 
 The interval must be greater than zero or `Timer` returns `ErrInvalidInterval`.
 

--- a/serve_test.go
+++ b/serve_test.go
@@ -273,6 +273,25 @@ func TestTimerStartError(t *testing.T) {
 	require.NoError(t, signal.Serve(t.Context()))
 }
 
+func TestTimerStartErrorStopsHook(t *testing.T) {
+	stopped := false
+	stopErr := errors.New("signal: timer start stop error")
+
+	err := signal.Timer(t.Context(), time.Second, time.Millisecond, signal.Hook{
+		OnStart: func(context.Context) error {
+			return errServe
+		},
+		OnStop: func(context.Context) error {
+			stopped = true
+			return stopErr
+		},
+	})
+
+	require.ErrorIs(t, err, errServe)
+	require.ErrorIs(t, err, stopErr)
+	require.True(t, stopped)
+}
+
 func TestTimerTickStopError(t *testing.T) {
 	signal.SetDefault(signal.NewLifeCycle(time.Minute))
 	signal.Register(signal.Hook{
@@ -291,6 +310,25 @@ func TestTimerTickStopError(t *testing.T) {
 	}()
 
 	require.NoError(t, signal.Serve(t.Context()))
+}
+
+func TestTimerTickErrorStopsHook(t *testing.T) {
+	stopped := false
+	stopErr := errors.New("signal: timer tick stop error")
+
+	err := signal.Timer(t.Context(), time.Second, time.Millisecond, signal.Hook{
+		OnTick: func(context.Context) error {
+			return errServe
+		},
+		OnStop: func(context.Context) error {
+			stopped = true
+			return stopErr
+		},
+	})
+
+	require.ErrorIs(t, err, errServe)
+	require.ErrorIs(t, err, stopErr)
+	require.True(t, stopped)
 }
 
 func TestTimerTickError(t *testing.T) {

--- a/signal.go
+++ b/signal.go
@@ -15,8 +15,9 @@ import (
 // Timer runs hook.Start once, then calls hook.Tick at the given interval until
 // ctx is done.
 //
-// When ctx is cancelled, Timer calls hook.Stop with a fresh background context
-// bounded by timeout. Nil hook callbacks are treated as no-ops.
+// If ctx is cancelled or a timer hook returns an error, Timer calls hook.Stop
+// with a fresh background context bounded by timeout before returning. Nil hook
+// callbacks are treated as no-ops.
 //
 // Timer executes its work through [Go], so a [Terminated] error still triggers
 // [Shutdown]. The interval must be greater than zero.
@@ -30,19 +31,16 @@ func Timer(ctx context.Context, timeout, interval time.Duration, hook Hook) erro
 		defer ticker.Stop()
 
 		if err := hook.Start(ctx); err != nil {
-			return err
+			return errors.Join(err, stopHook(timeout, hook))
 		}
 
 		for {
 			select {
 			case <-ctx.Done():
-				stopCtx, cancel := context.WithTimeout(context.Background(), timeout)
-				defer cancel()
-
-				return hook.Stop(stopCtx)
+				return stopHook(timeout, hook)
 			case <-ticker.C:
 				if err := hook.Tick(ctx); err != nil {
-					return err
+					return errors.Join(err, stopHook(timeout, hook))
 				}
 			}
 		}
@@ -306,6 +304,13 @@ func (l *Lifecycle) start(ctx context.Context) ([]Hook, error) {
 
 func (l *Lifecycle) stopContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), l.timeout)
+}
+
+func stopHook(timeout time.Duration, hook Hook) error {
+	stopCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	return hook.Stop(stopCtx)
 }
 
 func (l *Lifecycle) stop(ctx context.Context, hooks []Hook) error {


### PR DESCRIPTION
## What

- updated `Timer` to run `hook.OnStop` with a fresh timeout-bound context when `OnStart` or `OnTick` fails
- joined cleanup errors with the original timer failure so both are returned
- added regression tests covering timer start and tick failures with cleanup
- refreshed the timer documentation in code and README

## Why

`Timer` previously only ran `OnStop` when the parent context ended. If startup or a tick failed, cleanup was skipped entirely. This change makes timer hooks behave like a proper start/stop pair even on failure paths.

## Testing

```sh
env GOCACHE=/tmp/go-build go test ./...
```