### PR TITLE
feat(docs): go wait semantics and serve signal handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ shutdown is requested.
 - It waits for `SIGINT` or `SIGTERM`, or for the parent context to be canceled.
 - It then runs stop hooks with a fresh background context bounded by the
   lifecycle timeout.
+- During signal takeover, there is a narrow startup handoff window where an
+  incoming `SIGINT` or `SIGTERM` may need to be sent again.
 
 While `Serve` is active it takes ownership of `SIGINT` and `SIGTERM`, so other
 signal handlers for those signals will not run during that time.
@@ -146,9 +148,14 @@ from a background goroutine that wants to stop a running `Serve` loop.
 `Go` runs a handler with a timeout-aware wait. It is useful for long-running
 background work that should share a lifecycle context.
 
-If the handler returns an error marked with `signal.Terminated(err)`, `Go`
-triggers `Shutdown()` before returning the error. That gives background work a
-way to request that `Serve` stop.
+- `Go` only reports errors observed before its timeout or parent context
+  cancellation.
+- If the worker keeps running after that waiting window, later non-terminated
+  errors are not returned to the caller.
+- If the handler returns an error marked with `signal.Terminated(err)`, `Go`
+  triggers `Shutdown()` before returning the error.
+- If that terminated error happens after the waiting window has elapsed,
+  `Shutdown()` is still triggered, but `Go` has already returned `nil`.
 
 ```go
 import (

--- a/signal.go
+++ b/signal.go
@@ -70,11 +70,17 @@ func IsTerminated(err error) bool {
 	return errors.Is(err, ErrTerminated)
 }
 
-// Go runs handler with ctx and waits for it to complete, subject to timeout.
+// Go runs handler with ctx and waits up to timeout for it to complete.
+//
+// Go is a best-effort waiting helper. If timeout elapses or ctx is done first,
+// Go returns nil immediately while handler may continue running in the
+// background.
 //
 // If handler returns an error marked with [ErrTerminated], Go triggers
-// [Shutdown] before returning the error. This lets long-running goroutines ask a
-// concurrently running [Serve] loop to stop.
+// [Shutdown] before returning the error. If that terminated error arrives after
+// the waiting window has elapsed, Shutdown is still triggered from the
+// background goroutine, but Go has already returned nil. Other late errors are
+// not returned to the caller.
 func Go(ctx context.Context, timeout time.Duration, handler Handler) error {
 	return sync.Wait(ctx, timeout, sync.Hook{
 		OnRun: sync.Handler(handler),
@@ -250,6 +256,10 @@ func (l *Lifecycle) Run(ctx context.Context, h Handler) error {
 //
 // Note: Serve takes ownership of SIGINT and SIGTERM for the process while it is
 // active. Other handlers for those signals will not run during that time.
+//
+// Because Serve resets and re-registers SIGINT and SIGTERM handling during
+// startup, there is a narrow handoff window in which an arriving signal may
+// need to be sent again.
 func (l *Lifecycle) Serve(ctx context.Context) error {
 	signals := []os.Signal{os.Interrupt, syscall.SIGTERM}
 


### PR DESCRIPTION
## What

- clarified `Go` documentation to describe its best-effort wait behavior
- documented that late non-terminated errors are not returned and late terminated errors can still trigger shutdown after `Go` returns
- added a `Serve` note about the narrow signal handoff window during startup
- updated both code comments and README so the behavior is documented consistently

## Why

These behaviors are intentional enough to keep, but surprising enough that they should be explicit. Documenting them reduces confusion for callers using `Go` for background workers and `Serve` for signal ownership.

## Testing

- not run, doc-only changes