### PR TITLE
feat(context): use package timeout causes for lifecycle shutdown contexts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Primary public API lives in `signal.go`:
 - `signal.Shutdown()`
 - `signal.Go(ctx, timeout, handler)`
 - `signal.Timer(ctx, timeout, interval, hook)`
+- `signal.ErrTimeout`
 - `signal.NewLifeCycle(timeout)`
 - `signal.SetDefault(lifecycle)` and `signal.Default()`
 
@@ -130,6 +131,7 @@ stored under `test/reports/`.
 - if startup fails, it rolls back by running stop hooks only for successfully started hooks using the caller context
 - if all start hooks succeed, it runs the supplied handler
 - after successful startup, stop hooks run even if the handler returns an error
+- if a stop hook returns `context.Cause(ctx)` after the lifecycle stop context expires, the returned error matches `signal.ErrTimeout`
 - stop collects all hook errors with `errors.Join`
 
 ### Serve semantics
@@ -140,6 +142,7 @@ stored under `test/reports/`.
 - it creates a `signal.NotifyContext` and blocks until shutdown is requested
 - shutdown can come from parent context cancellation, an OS signal, or `signal.Shutdown()`
 - stop hooks run with a fresh background context bounded by the lifecycle timeout
+- if a stop hook returns `context.Cause(ctx)` after that stop context expires, the returned error matches `signal.ErrTimeout`
 - while `Serve` is active, other handlers for `SIGINT` and `SIGTERM` will not run
 
 ### Shutdown and termination
@@ -153,6 +156,7 @@ stored under `test/reports/`.
 
 - `signal.Timer` runs `hook.Start` once, then `hook.Tick` at the requested interval
 - when the parent context ends, `Timer` runs `hook.Stop` with a fresh timeout-bound context
+- if that timeout-bound stop context expires and the hook returns `context.Cause(ctx)`, the returned error matches `signal.ErrTimeout`
 - `interval <= 0` returns `ErrInvalidInterval`
 - `Timer` executes through `signal.Go`, so terminated errors still request shutdown
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ The package centers on a `Lifecycle` that runs hooks in three phases:
 The package-level helpers operate on a process-wide default lifecycle initialized
 with a 30 second stop timeout.
 
+`signal.ErrTimeout` is the package-owned timeout cause used for lifecycle stop
+contexts and timer stop hooks. It wraps `sync.ErrTimeout`, which in turn wraps
+`context.DeadlineExceeded`.
+
 ## Install
 
 ```sh
@@ -54,6 +58,8 @@ signal.Register(signal.Hook{
   started successfully.
 - `Run` executes rollback and stop hooks with a fresh background context bounded
   by the lifecycle timeout.
+- If a rollback or stop hook returns `context.Cause(ctx)` after that stop
+  context expires, the returned error matches `signal.ErrTimeout`.
 - After successful startup, `Run` always runs stop hooks, even if the handler
   fails.
 - Startup, handler, and stop-hook errors are combined with `errors.Join`.
@@ -93,6 +99,8 @@ shutdown is requested.
 - It waits for `SIGINT` or `SIGTERM`, or for the parent context to be canceled.
 - It then runs stop hooks with a fresh background context bounded by the
   lifecycle timeout.
+- If a stop hook returns `context.Cause(ctx)` after that stop context expires,
+  the returned error matches `signal.ErrTimeout`.
 - During signal takeover, there is a narrow startup handoff window where an
   incoming `SIGINT` or `SIGTERM` may need to be sent again.
 
@@ -179,6 +187,8 @@ err := signal.Go(context.Background(), 5*time.Second, func(context.Context) erro
 - call `hook.OnTick` on each interval
 - when the parent context is canceled or a timer hook returns an error, call
   `hook.OnStop` with a fresh background context bounded by the supplied timeout
+- if that stop context expires and the hook returns `context.Cause(ctx)`, the
+  returned error matches `signal.ErrTimeout`
 
 The interval must be greater than zero or `Timer` returns `ErrInvalidInterval`.
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alexfalkowski/go-signal
 go 1.26.0
 
 require (
-	github.com/alexfalkowski/go-sync v1.19.3
+	github.com/alexfalkowski/go-sync v1.20.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/alexfalkowski/go-sync v1.19.3 h1:sEmPvRa08IjuQ44YpglQDhXpbex1YPQCwRkKqarejQc=
-github.com/alexfalkowski/go-sync v1.19.3/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
+github.com/alexfalkowski/go-sync v1.20.0 h1:p9GTlXKhncDY2sPLknsCQjYGtp6DvrRX6/sctThts78=
+github.com/alexfalkowski/go-sync v1.20.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/run_test.go
+++ b/run_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alexfalkowski/go-signal"
 	"github.com/alexfalkowski/go-signal/internal/test"
+	"github.com/alexfalkowski/go-sync"
 	"github.com/stretchr/testify/require"
 )
 
@@ -175,4 +176,22 @@ func TestRunHandlerAndStopError(t *testing.T) {
 
 	require.ErrorIs(t, err, errRun)
 	require.ErrorIs(t, err, stopErr)
+}
+
+func TestRunStopTimeoutCause(t *testing.T) {
+	signal.SetDefault(signal.NewLifeCycle(time.Microsecond))
+	signal.Register(signal.Hook{
+		OnStop: func(ctx context.Context) error {
+			<-ctx.Done()
+			return context.Cause(ctx)
+		},
+	})
+
+	err := signal.Run(t.Context(), func(context.Context) error {
+		return nil
+	})
+
+	require.ErrorIs(t, err, signal.ErrTimeout)
+	require.ErrorIs(t, err, sync.ErrTimeout)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }

--- a/signal.go
+++ b/signal.go
@@ -16,8 +16,9 @@ import (
 // ctx is done.
 //
 // If ctx is cancelled or a timer hook returns an error, Timer calls hook.Stop
-// with a fresh background context bounded by timeout before returning. Nil hook
-// callbacks are treated as no-ops.
+// with a fresh background context bounded by timeout before returning. If that
+// stop context expires and the stop hook returns [context.Cause], the returned
+// error matches [ErrTimeout]. Nil hook callbacks are treated as no-ops.
 //
 // Timer executes its work through [Go], so a [Terminated] error still triggers
 // [Shutdown]. The interval must be greater than zero.
@@ -50,6 +51,12 @@ func Timer(ctx context.Context, timeout, interval time.Duration, hook Hook) erro
 // ErrInvalidInterval reports that [Timer] was called with an interval less than
 // or equal to zero.
 var ErrInvalidInterval = errors.New("signal: invalid interval")
+
+// ErrTimeout is the timeout cause used by derived stop contexts in this package.
+//
+// It wraps [sync.ErrTimeout], so [errors.Is] also matches
+// [context.DeadlineExceeded].
+var ErrTimeout = fmt.Errorf("signal: %w", sync.ErrTimeout)
 
 // ErrTerminated marks an error as requesting process shutdown.
 //
@@ -216,7 +223,8 @@ func (l *Lifecycle) Register(h Hook) {
 // registration order with a fresh background context bounded by the lifecycle
 // timeout. If startup succeeds, it calls h, then calls each registered stop
 // hook in reverse registration order with the same kind of fresh shutdown
-// context.
+// context. If a stop hook returns [context.Cause] after that context expires,
+// the returned error matches [ErrTimeout].
 //
 // Startup, handler, and stop-hook errors are combined with [errors.Join].
 func (l *Lifecycle) Run(ctx context.Context, h Handler) error {
@@ -249,7 +257,8 @@ func (l *Lifecycle) Run(ctx context.Context, h Handler) error {
 //
 // After shutdown is requested, Serve runs stop hooks in reverse registration
 // order with a fresh background context bounded by the lifecycle timeout
-// configured by [NewLifeCycle].
+// configured by [NewLifeCycle]. If a stop hook returns [context.Cause] after
+// that context expires, the returned error matches [ErrTimeout].
 //
 // Note: Serve takes ownership of SIGINT and SIGTERM for the process while it is
 // active. Other handlers for those signals will not run during that time.
@@ -310,7 +319,7 @@ func (l *Lifecycle) start(ctx context.Context) ([]Hook, error) {
 }
 
 func (l *Lifecycle) stopContext() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), l.timeout)
+	return context.WithTimeoutCause(context.Background(), l.timeout, ErrTimeout)
 }
 
 func (l *Lifecycle) stop(ctx context.Context, hooks []Hook) error {
@@ -326,7 +335,7 @@ func (l *Lifecycle) stop(ctx context.Context, hooks []Hook) error {
 }
 
 func stopHook(timeout time.Duration, hook Hook) error {
-	stopCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	stopCtx, cancel := context.WithTimeoutCause(context.Background(), timeout, ErrTimeout)
 	defer cancel()
 
 	return hook.Stop(stopCtx)


### PR DESCRIPTION
## What

Introduce a package-owned `signal.ErrTimeout` for lifecycle shutdown contexts, make shutdown contexts use `context.WithTimeoutCause`, and update docs to describe the new timeout error semantics. Keep public-path test coverage focused on lifecycle shutdown behavior through `Run`.

## Why

This gives `go-signal` its own timeout sentinel while still preserving `errors.Is` compatibility with `sync.ErrTimeout` and `context.DeadlineExceeded`. It makes shutdown timeout errors clearer to callers without changing the underlying timeout matching behavior.

## Testing

- Added regression coverage for lifecycle stop timeout causes in `run_test.go`
- Updated docs in `README.md` and `AGENTS.md`
- Ran `env GOCACHE=/tmp/go-build GOTMPDIR=/tmp go test ./...`