### PR TITLE
fix(signal): add default lifecycle constructor and harden default reset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,99 +3,53 @@
 ## Shared skill
 
 Use the shared `coding-standards` skill from `./bin/skills/coding-standards`
-for cross-repository coding, review, testing, documentation, and PR
-conventions. Treat this `AGENTS.md` as the repo-specific companion to that
-skill.
+for general coding, review, testing, documentation, and PR conventions. This
+file only captures repo-specific guidance.
 
-## Overview
+## Repo
 
 - Module: `github.com/alexfalkowski/go-signal`
-- Purpose: small Go library for coordinating application start/stop hooks around OS signals
+- Purpose: Go library for coordinating startup and shutdown hooks around OS
+  signals
 - Go version: `1.26.0`
-
-Primary public API lives in `signal.go`:
-
-- `signal.Register(Hook)`
-- `signal.Run(ctx, handler)`
-- `signal.Serve(ctx)`
-- `signal.Shutdown()`
-- `signal.Go(ctx, timeout, handler)`
-- `signal.Timer(ctx, timeout, interval, hook)`
-- `signal.ErrTimeout`
-- `signal.NewLifeCycle(timeout)`
-- `signal.SetDefault(lifecycle)` and `signal.Default()`
+- Public API: `Register`, `Run`, `Serve`, `Shutdown`, `Go`, `Timer`,
+  `ErrTimeout`, `NewDefaultLifecycle`, `NewLifeCycle`, `SetDefault`, `Default`
 
 ## Layout
 
 - `signal.go`: library implementation
-- `internal/test/`: shared test helpers for startup rollback scenarios
-- `cmd/main.go`: runnable example used by `make run`
-- `run_test.go`: tests for `Run`
-- `serve_test.go`: tests for `Serve` and `Timer`
+- `run_test.go`: `Run` coverage
+- `serve_test.go`: `Serve` and `Timer` coverage
 - `signal_test.go`: integration-style tests
-- `README.md`: user-facing package documentation
-- `.circleci/config.yml`: CI workflow
-- `bin/`: git submodule with shared Make tooling
+- `internal/test/`: shared rollback test helpers
+- `cmd/main.go`: runnable example for `make run`
+- `README.md`: user-facing docs
+- `.circleci/config.yml`: CI source of truth
+- `bin/`: shared make tooling submodule
 
-## Tooling
+## Commands
 
-The top-level `Makefile` includes Makefiles from the `bin/` submodule, so most
-`make` targets depend on `bin/` being initialized:
+Most `make` targets depend on `bin/` being initialized:
 
 ```sh
 git submodule sync
 git submodule update --init
 ```
 
-The submodule URL is SSH-based: `git@github.com:alexfalkowski/bin.git`.
-
-Formatting defaults from `.editorconfig`:
-
-- LF line endings
-- tabs for `*.go`
-- tabs for `Makefile`
-
-## Key commands
-
-Run the example:
+Primary commands:
 
 ```sh
+make dep
+make lint
+make sec
+make specs
+make coverage
 make run param=start
 make run param=timer
 make run param=terminate
 ```
 
-Dependency maintenance:
-
-```sh
-make dep
-make clean
-```
-
-Tests:
-
-```sh
-go test ./...
-make specs
-```
-
-Lint and security:
-
-```sh
-make lint
-make fix-lint
-make sec
-```
-
-Coverage:
-
-```sh
-make coverage
-```
-
-## CI
-
-CircleCI runs the main build job in this order:
+CI build order:
 
 ```sh
 make source-key
@@ -109,68 +63,43 @@ make coverage
 make codecov-upload
 ```
 
-`make source-key` writes `.source-key`. Test reports and coverage artifacts are
-stored under `test/reports/`.
+## Repo-specific behavior
 
-## Behavior notes
-
-### Lifecycle model
-
-- The package keeps a process-wide default lifecycle in `sync.Pointer[Lifecycle]`.
-- The default lifecycle is initialized in `init()` with a 30 second stop timeout.
-- Tests often replace it with `signal.SetDefault(signal.NewLifeCycle(...))`.
-
-### Hooks
-
-- `Hook` callbacks are optional: `OnStart`, `OnTick`, and `OnStop`
-- `Hook.Start`, `Hook.Tick`, and `Hook.Stop` return `nil` when the callback is unset
-
-### Registration
-
-- `Lifecycle.Register` appends to an internal slice
-- registration is not designed to be concurrent-safe
-- register hooks during setup, before calling `Run` or `Serve`
-
-### Run semantics
-
-- `Lifecycle.Run` runs start hooks in registration order
-- it attempts all start hooks and collects startup errors with `errors.Join`
-- if startup fails, it rolls back by running stop hooks only for successfully started hooks using the caller context
-- if all start hooks succeed, it runs the supplied handler
-- after successful startup, stop hooks run even if the handler returns an error
-- if a stop hook returns `context.Cause(ctx)` after the lifecycle stop context expires, the returned error matches `signal.ErrTimeout`
-- stop collects all hook errors with `errors.Join`
-
-### Serve semantics
-
-- `Lifecycle.Serve` resets and ignores existing `SIGINT` and `SIGTERM` handlers
-- it attempts all start hooks and collects startup errors with `errors.Join`
-- if startup fails, it rolls back successfully started hooks with a fresh background context bounded by the lifecycle timeout and returns without entering the wait loop
-- it creates a `signal.NotifyContext` and blocks until shutdown is requested
-- shutdown can come from parent context cancellation, an OS signal, or `signal.Shutdown()`
-- stop hooks run with a fresh background context bounded by the lifecycle timeout
-- if a stop hook returns `context.Cause(ctx)` after that stop context expires, the returned error matches `signal.ErrTimeout`
-- while `Serve` is active, other handlers for `SIGINT` and `SIGTERM` will not run
-
-### Shutdown and termination
-
-- `Lifecycle.Shutdown` sends `os.Interrupt` to the current process
-- `signal.Terminated(err)` marks an error with `ErrTerminated`
-- `signal.IsTerminated(err)` checks that marker via `errors.Is`
-- `signal.Go` triggers `signal.Shutdown()` when it sees a terminated error
-
-### Timer
-
-- `signal.Timer` runs `hook.Start` once, then `hook.Tick` at the requested interval
-- when the parent context ends, `Timer` runs `hook.Stop` with a fresh timeout-bound context
-- if that timeout-bound stop context expires and the hook returns `context.Cause(ctx)`, the returned error matches `signal.ErrTimeout`
-- `interval <= 0` returns `ErrInvalidInterval`
-- `Timer` executes through `signal.Go`, so terminated errors still request shutdown
+- The package keeps a process-wide default lifecycle in
+  `sync.Pointer[Lifecycle]`.
+- The default lifecycle is initialized in `init()` with
+  `signal.NewDefaultLifecycle()`, which uses a 30 second stop timeout.
+- `Hook` callbacks are optional. `Hook.Start`, `Hook.Tick`, and `Hook.Stop`
+  treat nil callbacks as no-ops.
+- `Lifecycle.Register` is not concurrent-safe. Register hooks during setup,
+  before `Run` or `Serve`.
+- `Lifecycle.Run` starts hooks in registration order, attempts every start hook,
+  joins startup errors, rolls back only successfully started hooks on startup
+  failure, and always runs stop hooks after successful startup.
+- `Lifecycle.Run` rollback and shutdown hooks use fresh timeout-bound stop
+  contexts. Returning `context.Cause(ctx)` from an expired stop context should
+  match `signal.ErrTimeout`.
+- `Lifecycle.Serve` resets and takes ownership of `SIGINT` and `SIGTERM` while
+  active.
+- `Lifecycle.Serve` startup failure still attempts remaining start hooks, then
+  rolls back successfully started hooks with a fresh timeout-bound background
+  context.
+- `Lifecycle.Serve` shutdown can come from parent context cancellation, an OS
+  signal, or `signal.Shutdown()`.
+- `Lifecycle.Shutdown` sends `os.Interrupt` to the current process.
+- `signal.Terminated(err)` marks an error with `ErrTerminated`,
+  `signal.IsTerminated(err)` checks that marker, and `signal.Go` triggers
+  `signal.Shutdown()` when it sees a terminated error.
+- `signal.Timer` runs `hook.Start` once, then `hook.Tick` on each interval, and
+  runs `hook.Stop` with a fresh timeout-bound context when the parent context
+  ends or a timer hook returns an error.
+- `signal.Timer` returns `ErrInvalidInterval` for `interval <= 0`.
 
 ## Testing notes
 
-- tests use `package signal_test`
-- many `Serve` and `Timer` tests unblock `signal.Serve(...)` by calling `signal.Shutdown()` from a goroutine after `time.Sleep(time.Second)`
-- these tests are intentionally timing-sensitive
-- `TestHTTPServe` binds to `127.0.0.1:0` instead of a fixed port
-- tests commonly pass `t.Context()` into library calls
+- Tests use `package signal_test`.
+- Many `Serve` and `Timer` tests intentionally unblock with
+  `signal.Shutdown()` after `time.Sleep(time.Second)`.
+- Those tests are timing-sensitive by design.
+- `TestHTTPServe` binds to `127.0.0.1:0`.
+- Tests commonly pass `t.Context()` into library calls.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The package centers on a `Lifecycle` that runs hooks in three phases:
 - stop: call each registered `OnStop`
 
 The package-level helpers operate on a process-wide default lifecycle initialized
-with a 30 second stop timeout.
+with `NewDefaultLifecycle()`, which uses a 30 second stop timeout.
 
 `signal.ErrTimeout` is the package-owned timeout cause used for lifecycle stop
 contexts and timer stop hooks. It wraps `sync.ErrTimeout`, which in turn wraps
@@ -30,6 +30,11 @@ go get github.com/alexfalkowski/go-signal
 ```
 
 ## Core API
+
+### NewDefaultLifecycle
+
+Use `NewDefaultLifecycle` when you want the package's standard lifecycle
+configuration without relying on the package-level singleton.
 
 ### Register
 
@@ -222,8 +227,9 @@ signal.Register(signal.Hook{
 
 ## Custom lifecycle
 
-Use `NewLifeCycle` when you do not want to rely on the package-level default
-lifecycle.
+Use `NewLifeCycle` when you need a custom stop timeout. Use
+`NewDefaultLifecycle` when you want the same 30 second timeout as the
+package-level default, but on your own lifecycle instance.
 
 ```go
 import (

--- a/run_test.go
+++ b/run_test.go
@@ -23,6 +23,48 @@ func TestRunEmpty(t *testing.T) {
 	}))
 }
 
+func TestSetDefaultNilResetsLifecycle(t *testing.T) {
+	lifecycle := signal.NewLifeCycle(time.Minute)
+	lifecycle.Register(signal.Hook{
+		OnStart: func(context.Context) error {
+			return errRun
+		},
+	})
+
+	signal.SetDefault(lifecycle)
+	signal.SetDefault(nil)
+
+	started := false
+	signal.Register(signal.Hook{
+		OnStart: func(context.Context) error {
+			started = true
+			return nil
+		},
+	})
+
+	require.NoError(t, signal.Run(t.Context(), func(context.Context) error {
+		return nil
+	}))
+	require.True(t, started)
+}
+
+func TestNewDefaultLifecycle(t *testing.T) {
+	lifecycle := signal.NewDefaultLifecycle()
+	started := false
+
+	lifecycle.Register(signal.Hook{
+		OnStart: func(context.Context) error {
+			started = true
+			return nil
+		},
+	})
+
+	require.NoError(t, lifecycle.Run(t.Context(), func(context.Context) error {
+		return nil
+	}))
+	require.True(t, started)
+}
+
 func TestRunError(t *testing.T) {
 	signal.SetDefault(signal.NewLifeCycle(time.Minute))
 	stopped := false

--- a/serve_test.go
+++ b/serve_test.go
@@ -192,6 +192,7 @@ func TestServeStartLoopContext(t *testing.T) {
 					select {
 					case <-ctx.Done():
 						ch <- true
+						return nil
 					default:
 						time.Sleep(time.Millisecond)
 					}

--- a/signal.go
+++ b/signal.go
@@ -149,13 +149,13 @@ func (h Hook) Stop(ctx context.Context) error {
 var defaultLifecycle sync.Pointer[Lifecycle]
 
 func init() {
-	defaultLifecycle.Store(NewLifeCycle(30 * time.Second))
+	defaultLifecycle.Store(NewDefaultLifecycle())
 }
 
 // Default returns the process-wide default [Lifecycle].
 //
-// The default lifecycle is initialized during package init with a 30-second stop
-// timeout.
+// The default lifecycle is initialized during package init with
+// [NewDefaultLifecycle].
 func Default() *Lifecycle {
 	return defaultLifecycle.Load()
 }
@@ -163,8 +163,13 @@ func Default() *Lifecycle {
 // SetDefault replaces the process-wide default [Lifecycle].
 //
 // Callers typically use this in tests or when they want package-level helpers
-// such as [Register], [Run], and [Serve] to target a custom lifecycle.
+// such as [Register], [Run], and [Serve] to target a custom lifecycle. If l is
+// nil, SetDefault restores a fresh lifecycle from [NewDefaultLifecycle].
 func SetDefault(l *Lifecycle) {
+	if l == nil {
+		l = NewDefaultLifecycle()
+	}
+
 	defaultLifecycle.Store(l)
 }
 
@@ -186,6 +191,12 @@ func Serve(ctx context.Context) error {
 // Shutdown calls [Lifecycle.Shutdown] on the default [Lifecycle].
 func Shutdown() error {
 	return Default().Shutdown()
+}
+
+// NewDefaultLifecycle returns a new empty [Lifecycle] with the package's
+// default 30-second stop timeout.
+func NewDefaultLifecycle() *Lifecycle {
+	return NewLifeCycle(30 * time.Second)
 }
 
 // NewLifeCycle returns a new empty [Lifecycle] configured with the given stop


### PR DESCRIPTION
## What

- Added `signal.NewDefaultLifecycle()` and switched package initialization to use it for the process-wide default lifecycle.
- Updated `signal.SetDefault` so passing `nil` restores a fresh default lifecycle instead of leaving later package-level calls vulnerable to a panic.
- Added tests covering `SetDefault(nil)` and `NewDefaultLifecycle()`.
- Fixed the leaking goroutine in the `Serve` context loop test by returning after cancellation is observed.
- Updated [README.md](/Users/alejandro/code/go-signal/README.md) and [AGENTS.md](/Users/alejandro/code/go-signal/AGENTS.md) to document the new exported API and default lifecycle behavior.

## Why

- The default lifecycle behavior is part of the public surface, so exposing `NewDefaultLifecycle()` makes that standard configuration explicit and reusable.
- Treating `SetDefault(nil)` as a reset-to-default is safer than allowing a delayed nil dereference through `Register`, `Run`, `Serve`, or `Shutdown`.
- The test fix removes a background goroutine leak and keeps lifecycle shutdown coverage honest.

## Testing

- Ran `gofmt -w signal.go run_test.go`
- Ran `make lint`
- Ran `make specs`