### PR TITLE
fix(signal): harden termination handling and example CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,9 @@ err := signal.Go(context.Background(), 5*time.Second, func(context.Context) erro
 
 - call `hook.OnStart` once
 - call `hook.OnTick` on each interval
-- when the parent context is canceled or a timer hook returns an error, call
-  `hook.OnStop` with a fresh background context bounded by the supplied timeout
+- if `hook.OnStart` fails, or when the parent context is canceled or a timer
+  hook returns an error, call `hook.OnStop` with a fresh background context
+  bounded by the supplied timeout
 - if that stop context expires and the hook returns `context.Cause(ctx)`, the
   returned error matches `signal.ErrTimeout`
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"time"
@@ -10,6 +12,13 @@ import (
 )
 
 var logger = slog.Default()
+
+const usageMessage = "usage: go run cmd/main.go [start|timer|terminate]"
+
+var (
+	errUsage       = errors.New(usageMessage)
+	errInvalidMode = errors.New("invalid mode")
+)
 
 func start(ctx context.Context) error {
 	<-ctx.Done()
@@ -32,8 +41,8 @@ func terminate(_ context.Context) error {
 	return signal.Terminated(context.Canceled)
 }
 
-func main() {
-	switch os.Args[1] {
+func configure(mode string) error {
+	switch mode {
 	case "start":
 		signal.Register(signal.Hook{
 			OnStart: func(ctx context.Context) error {
@@ -80,9 +89,35 @@ func main() {
 				return ctx.Err()
 			},
 		})
+	default:
+		return fmt.Errorf("%w %q: %s", errInvalidMode, mode, usageMessage)
 	}
 
-	if err := signal.Serve(context.Background()); err != nil {
-		logger.Info("server failed", "error", err)
+	return nil
+}
+
+func run(args []string) error {
+	if len(args) < 2 {
+		return errUsage
 	}
+
+	if err := configure(args[1]); err != nil {
+		return err
+	}
+
+	return signal.Serve(context.Background())
+}
+
+func main() {
+	err := run(os.Args)
+	if err == nil {
+		return
+	}
+
+	if errors.Is(err, errUsage) || errors.Is(err, errInvalidMode) {
+		logger.Error(err.Error())
+		os.Exit(2)
+	}
+
+	logger.Info("server failed", "error", err)
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunWithoutMode(t *testing.T) {
+	require.ErrorIs(t, run([]string{"go-signal"}), errUsage)
+}
+
+func TestRunWithInvalidMode(t *testing.T) {
+	err := run([]string{"go-signal", "unknown"})
+
+	require.ErrorIs(t, err, errInvalidMode)
+	require.ErrorContains(t, err, usageMessage)
+}

--- a/serve_test.go
+++ b/serve_test.go
@@ -361,3 +361,10 @@ func TestTimerNegativeInterval(t *testing.T) {
 	err := signal.Timer(t.Context(), time.Second, -time.Second, signal.Hook{})
 	require.ErrorIs(t, err, signal.ErrInvalidInterval)
 }
+
+func TestTerminatedNil(t *testing.T) {
+	err := signal.Terminated(nil)
+
+	require.ErrorIs(t, err, signal.ErrTerminated)
+	require.EqualError(t, err, signal.ErrTerminated.Error())
+}

--- a/signal.go
+++ b/signal.go
@@ -15,10 +15,11 @@ import (
 // Timer runs hook.Start once, then calls hook.Tick at the given interval until
 // ctx is done.
 //
-// If ctx is cancelled or a timer hook returns an error, Timer calls hook.Stop
-// with a fresh background context bounded by timeout before returning. If that
-// stop context expires and the stop hook returns [context.Cause], the returned
-// error matches [ErrTimeout]. Nil hook callbacks are treated as no-ops.
+// If hook.Start fails, or if ctx is cancelled or a timer hook returns an
+// error, Timer calls hook.Stop with a fresh background context bounded by
+// timeout before returning. If that stop context expires and the stop hook
+// returns [context.Cause], the returned error matches [ErrTimeout]. Nil hook
+// callbacks are treated as no-ops.
 //
 // Timer executes its work through [Go], so a [Terminated] error still triggers
 // [Shutdown]. The interval must be greater than zero.
@@ -67,8 +68,13 @@ var ErrTerminated = errors.New("signal: terminated")
 // Terminated wraps err so that [IsTerminated] reports true.
 //
 // This is typically used by background work started with [Go] to signal that a
-// concurrently running [Serve] loop should exit.
+// concurrently running [Serve] loop should exit. If err is nil, Terminated
+// returns [ErrTerminated].
 func Terminated(err error) error {
+	if err == nil {
+		return ErrTerminated
+	}
+
 	return fmt.Errorf("%w: %w", err, ErrTerminated)
 }
 


### PR DESCRIPTION
## What

- Return a clean `ErrTerminated` from `signal.Terminated(nil)` instead of producing a malformed wrapped error.
- Add regression coverage for the `Terminated(nil)` case.
- Update `Timer` docs in GoDoc and `README.md` to reflect that `OnStop` also runs after `OnStart` fails.
- Refactor the runnable example in `cmd/main.go` to validate arguments, print usage for missing or invalid modes, and avoid panicking on `os.Args[1]`.
- Add example-command tests for missing and invalid modes in `cmd/main_test.go`.

## Why

- `Terminated(nil)` is part of the public API surface, so it should behave predictably and produce a sensible error.
- The docs had drifted from the actual `Timer` behavior that is already implemented and tested.
- The example command is user-facing and should fail cleanly instead of crashing when invoked without the expected mode.

## Testing

- `make dep`
- `go test ./...`
- `make lint`