### PR TITLE
docs(agents): serve lifecycle and compress agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,105 +1,65 @@
 # AGENTS.md
 
-## Shared skill
-
-Use the shared `coding-standards` skill from `./bin/skills/coding-standards`
-for general coding, review, testing, documentation, and PR conventions. This
-file only captures repo-specific guidance.
+Use `./bin/skills/coding-standards` for shared coding, review, test,
+documentation, and PR conventions. This file only adds repo-specific context.
 
 ## Repo
 
-- Module: `github.com/alexfalkowski/go-signal`
-- Purpose: Go library for coordinating startup and shutdown hooks around OS
-  signals
-- Go version: `1.26.0`
-- Public API: `Register`, `Run`, `Serve`, `Shutdown`, `Go`, `Timer`,
-  `ErrTimeout`, `NewDefaultLifecycle`, `NewLifeCycle`, `SetDefault`, `Default`
-
-## Layout
-
-- `signal.go`: library implementation
-- `run_test.go`: `Run` coverage
-- `serve_test.go`: `Serve` and `Timer` coverage
-- `signal_test.go`: integration-style tests
-- `internal/test/`: shared rollback test helpers
-- `cmd/main.go`: runnable example for `make run`
-- `README.md`: user-facing docs
-- `.circleci/config.yml`: CI source of truth
-- `bin/`: shared make tooling submodule
+- Module: `github.com/alexfalkowski/go-signal`.
+- Read current toolchain details from repo files such as `go.mod`,
+  `.circleci/config.yml`, and `bin/`; do not duplicate them here.
+- Purpose: small library for startup/shutdown hooks around OS signals.
+- Main files: `signal.go`, `run_test.go`, `serve_test.go`, `signal_test.go`,
+  `internal/test/`, `cmd/main.go`, `README.md`, `.circleci/config.yml`.
+- Public surface includes lifecycle helpers (`Register`, `Run`, `Serve`,
+  `Shutdown`, `Go`, `Timer`), lifecycle constructors/defaults, hooks, and
+  sentinel helpers/errors.
 
 ## Commands
 
-Most `make` targets depend on `bin/` being initialized:
+Initialize shared tooling first when needed:
 
 ```sh
 git submodule sync
 git submodule update --init
 ```
 
-Primary commands:
+Common targets: `make dep`, `make lint`, `make sec`, `make specs`,
+`make coverage`, `make run param=start|timer|terminate`.
 
-```sh
-make dep
-make lint
-make sec
-make specs
-make coverage
-make run param=start
-make run param=timer
-make run param=terminate
-```
+CI order: `make source-key`, `make clean`, `make dep`, `make clean`,
+`make lint`, `make sec`, `make specs`, `make coverage`,
+`make codecov-upload`.
 
-CI build order:
+## Behavior
 
-```sh
-make source-key
-make clean
-make dep
-make clean
-make lint
-make sec
-make specs
-make coverage
-make codecov-upload
-```
-
-## Repo-specific behavior
-
-- The package keeps a process-wide default lifecycle in
-  `sync.Pointer[Lifecycle]`.
-- The default lifecycle is initialized in `init()` with
-  `signal.NewDefaultLifecycle()`, which uses a 30 second stop timeout.
-- `Hook` callbacks are optional. `Hook.Start`, `Hook.Tick`, and `Hook.Stop`
-  treat nil callbacks as no-ops.
-- `Lifecycle.Register` is not concurrent-safe. Register hooks during setup,
-  before `Run` or `Serve`.
-- `Lifecycle.Run` starts hooks in registration order, attempts every start hook,
-  joins startup errors, rolls back only successfully started hooks on startup
-  failure, and always runs stop hooks after successful startup.
-- `Lifecycle.Run` rollback and shutdown hooks use fresh timeout-bound stop
-  contexts. Returning `context.Cause(ctx)` from an expired stop context should
-  match `signal.ErrTimeout`.
-- `Lifecycle.Serve` resets and takes ownership of `SIGINT` and `SIGTERM` while
-  active.
-- `Lifecycle.Serve` startup failure still attempts remaining start hooks, then
-  rolls back successfully started hooks with a fresh timeout-bound background
-  context.
-- `Lifecycle.Serve` shutdown can come from parent context cancellation, an OS
+- The package stores a process-wide default `*Lifecycle` in
+  `sync.Pointer[Lifecycle]`; `init()` sets it to `NewDefaultLifecycle()` with a
+  30 second stop timeout.
+- `Hook` callbacks are optional; `Start`, `Tick`, and `Stop` treat nil
+  callbacks as no-ops.
+- `Lifecycle.Register` is setup-time only, before `Run` or `Serve`; it is not
+  concurrent-safe.
+- `Run` starts all hooks in registration order, joins startup errors, rolls back
+  only successfully started hooks on startup failure, and always runs stop hooks
+  after successful startup.
+- `Run`, `Serve`, and `Timer` use fresh timeout-bound background contexts for
+  rollback/shutdown stop hooks. Returning `context.Cause(ctx)` from an expired
+  stop context should match `signal.ErrTimeout`.
+- `Serve` is a process-lifetime blocking call: it resets and owns `SIGINT` and
+  `SIGTERM` while active, and shutdown can come from parent cancellation, an OS
   signal, or `signal.Shutdown()`.
-- `Lifecycle.Shutdown` sends `os.Interrupt` to the current process.
-- `signal.Terminated(err)` marks an error with `ErrTerminated`,
-  `signal.IsTerminated(err)` checks that marker, and `signal.Go` triggers
-  `signal.Shutdown()` when it sees a terminated error.
-- `signal.Timer` runs `hook.Start` once, then `hook.Tick` on each interval, and
-  runs `hook.Stop` with a fresh timeout-bound context when the parent context
-  ends or a timer hook returns an error.
-- `signal.Timer` returns `ErrInvalidInterval` for `interval <= 0`.
+- `Shutdown` sends `os.Interrupt` to the current process.
+- `Terminated(err)` marks an error with `ErrTerminated`; `IsTerminated` checks
+  it; `Go` calls `Shutdown()` when it sees one.
+- `Timer` runs `hook.Start` once, ticks at the interval, stops on parent
+  cancellation or hook error, and returns `ErrInvalidInterval` for
+  `interval <= 0`.
 
-## Testing notes
+## Tests
 
-- Tests use `package signal_test`.
-- Many `Serve` and `Timer` tests intentionally unblock with
-  `signal.Shutdown()` after `time.Sleep(time.Second)`.
-- Those tests are timing-sensitive by design.
+- Tests use external package `signal_test` and commonly pass `t.Context()`.
+- Several `Serve` and `Timer` tests intentionally unblock via
+  `signal.Shutdown()` after `time.Sleep(time.Second)`; they are
+  timing-sensitive by design.
 - `TestHTTPServe` binds to `127.0.0.1:0`.
-- Tests commonly pass `t.Context()` into library calls.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ shutdown is requested.
 - During signal takeover, there is a narrow startup handoff window where an
   incoming `SIGINT` or `SIGTERM` may need to be sent again.
 
+`Serve` is intended to be used as a process-lifetime blocking call; callers
+normally return from `main` and let the process exit after `Serve` returns.
 While `Serve` is active it takes ownership of `SIGINT` and `SIGTERM`, so other
 signal handlers for those signals will not run during that time.
 

--- a/signal.go
+++ b/signal.go
@@ -279,6 +279,8 @@ func (l *Lifecycle) Run(ctx context.Context, h Handler) error {
 //
 // Note: Serve takes ownership of SIGINT and SIGTERM for the process while it is
 // active. Other handlers for those signals will not run during that time.
+// Serve is intended to be used as a process-lifetime blocking call; callers
+// normally return from main and let the process exit after Serve returns.
 //
 // Because Serve resets and re-registers SIGINT and SIGTERM handling during
 // startup, there is a narrow handoff window in which an arriving signal may


### PR DESCRIPTION
## What

- Clarified `Serve` docs in GoDoc and README as a process-lifetime blocking call.
- Compressed `AGENTS.md` while preserving repo-specific behavior, commands, and test notes.
- Removed hardcoded toolchain/version details from `AGENTS.md` and pointed agents to repo files instead.

## Why

- Makes the intended `Serve` usage explicit for future readers.
- Keeps agent guidance shorter and less likely to go stale as repo tooling changes.

## Testing

- Ran `gofmt -w signal.go`.
- Ran `go test ./...` after the `Serve` documentation update.
- Did not rerun tests after the final `AGENTS.md`-only wording change.