### PR TITLE
docs(readme): timer cleanup semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,14 @@ err := signal.Go(context.Background(), 5*time.Second, func(context.Context) erro
 - call `hook.OnStart` once
 - call `hook.OnTick` on each interval
 - if `hook.OnStart` fails, or when the parent context is canceled or a timer
-  hook returns an error, call `hook.OnStop` with a fresh background context
-  bounded by the supplied timeout
+  hook returns an error, the timer worker calls `hook.OnStop` with a fresh
+  background context bounded by the supplied timeout
 - if that stop context expires and the hook returns `context.Cause(ctx)`, the
   returned error matches `signal.ErrTimeout`
+
+Because `Timer` executes through `Go`, it uses best-effort waiting semantics:
+when the parent context is canceled or the wait timeout elapses first, `Timer`
+may return before the timer worker has run `hook.OnStop`.
 
 The interval must be greater than zero or `Timer` returns `ErrInvalidInterval`.
 

--- a/signal.go
+++ b/signal.go
@@ -16,13 +16,15 @@ import (
 // ctx is done.
 //
 // If hook.Start fails, or if ctx is cancelled or a timer hook returns an
-// error, Timer calls hook.Stop with a fresh background context bounded by
-// timeout before returning. If that stop context expires and the stop hook
-// returns [context.Cause], the returned error matches [ErrTimeout]. Nil hook
-// callbacks are treated as no-ops.
+// error, the timer worker calls hook.Stop with a fresh background context
+// bounded by timeout. If that stop context expires and the stop hook returns
+// [context.Cause], the returned error matches [ErrTimeout]. Nil hook callbacks
+// are treated as no-ops.
 //
 // Timer executes its work through [Go], so a [Terminated] error still triggers
-// [Shutdown]. The interval must be greater than zero.
+// [Shutdown]. Because [Go] is a best-effort waiting helper, Timer may return
+// before the timer worker has run hook.Stop when ctx is cancelled or timeout
+// elapses first. The interval must be greater than zero.
 func Timer(ctx context.Context, timeout, interval time.Duration, hook Hook) error {
 	if interval <= 0 {
 		return fmt.Errorf("%w: %s", ErrInvalidInterval, interval)


### PR DESCRIPTION
## What

- Updated `Timer` GoDoc to describe cleanup as happening in the timer worker.
- Updated README Timer docs to note `Go` best-effort waiting semantics.
- Clarified that parent cancellation or wait timeout can make `Timer` return before `hook.OnStop` has run.

## Why

- Aligns public documentation with the actual `Go`-based implementation.
- Avoids implying synchronous cleanup-before-return behavior in cancellation and timeout paths.

## Testing

- Ran `gofmt -w signal.go`.
- Ran `go test ./...`; passed.