### PR TITLE
docs(security): explain serve signal ownership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test/reports/*.prof
 test/reports/coverage.html
 *.test
 .source-key
+ISSUES.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,10 @@ CI order: `make source-key`, `make clean`, `make dep`, `make clean`,
 - `Run`, `Serve`, and `Timer` use fresh timeout-bound background contexts for
   rollback/shutdown stop hooks. Returning `context.Cause(ctx)` from an expired
   stop context should match `signal.ErrTimeout`.
-- `Serve` is a process-lifetime blocking call: it resets and owns `SIGINT` and
-  `SIGTERM` while active, and shutdown can come from parent cancellation, an OS
-  signal, or `signal.Shutdown()`.
+- `Serve` is the final process-lifetime blocking call: it resets and owns
+  `SIGINT` and `SIGTERM`, does not restore prior signal handlers after
+  returning, and shutdown can come from parent cancellation, an OS signal, or
+  `signal.Shutdown()`.
 - `Shutdown` sends `os.Interrupt` to the current process.
 - `Terminated(err)` marks an error with `ErrTerminated`; `IsTerminated` checks
   it; `Go` calls `Shutdown()` when it sees one.

--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ shutdown is requested.
 - During signal takeover, there is a narrow startup handoff window where an
   incoming `SIGINT` or `SIGTERM` may need to be sent again.
 
-`Serve` is intended to be used as a process-lifetime blocking call; callers
-normally return from `main` and let the process exit after `Serve` returns.
-While `Serve` is active it takes ownership of `SIGINT` and `SIGTERM`, so other
-signal handlers for those signals will not run during that time.
+`Serve` is intended to be used as the final process-lifetime blocking call. It
+takes ownership of `SIGINT` and `SIGTERM`, does not restore prior signal
+handlers after returning, and callers should normally return from `main` after
+`Serve` returns.
 
 ```go
 import (

--- a/signal.go
+++ b/signal.go
@@ -280,10 +280,10 @@ func (l *Lifecycle) Run(ctx context.Context, h Handler) error {
 // configured by [NewLifeCycle]. If a stop hook returns [context.Cause] after
 // that context expires, the returned error matches [ErrTimeout].
 //
-// Note: Serve takes ownership of SIGINT and SIGTERM for the process while it is
-// active. Other handlers for those signals will not run during that time.
-// Serve is intended to be used as a process-lifetime blocking call; callers
-// normally return from main and let the process exit after Serve returns.
+// Note: Serve is intended to be used as the final process-lifetime blocking
+// call. It takes ownership of SIGINT and SIGTERM, does not restore prior signal
+// handlers after returning, and callers should normally return from main after
+// Serve returns.
 //
 // Because Serve resets and re-registers SIGINT and SIGTERM handling during
 // startup, there is a narrow handoff window in which an arriving signal may


### PR DESCRIPTION
## What

- Clarify that Serve is the final process-lifetime blocking call.
- Document that Serve owns SIGINT and SIGTERM and does not restore prior signal handlers after returning.
- Ignore local ISSUES.md review ledgers.

## Why

- Align the GoDoc, README, and agent guidance with the intended example usage where callers return from main after Serve returns.
- Prevent future review passes from treating the intentional non-restoration behavior as a bug.

## Testing

- `make lint` - passed
- `make specs` - passed
