### PR TITLE
feat(style): polish lifecycle readability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ CI order: `make source-key`, `make clean`, `make dep`, `make clean`,
 
 - The package stores a process-wide default `*Lifecycle` in
   `sync.Pointer[Lifecycle]`; `init()` sets it to `NewDefaultLifecycle()` with a
-  30 second stop timeout.
+  30-second stop timeout.
 - `Hook` callbacks are optional; `Start`, `Tick`, and `Stop` treat nil
   callbacks as no-ops.
 - `Lifecycle.Register` is setup-time only, before `Run` or `Serve`; it is not

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include bin/build/make/go.mak
 include bin/build/make/git.mak
 
-# Run a test.
+# Run the manual example.
 run:
 	@go run cmd/main.go $(param)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The package centers on a `Lifecycle` that runs hooks in three phases:
 - stop: call each registered `OnStop`
 
 The package-level helpers operate on a process-wide default lifecycle initialized
-with `NewDefaultLifecycle()`, which uses a 30 second stop timeout.
+with `NewDefaultLifecycle()`, which uses a 30-second stop timeout.
 
 `signal.ErrTimeout` is the package-owned timeout cause used for lifecycle stop
 contexts and timer stop hooks. It wraps `sync.ErrTimeout`, which in turn wraps
@@ -235,7 +235,7 @@ signal.Register(signal.Hook{
 ## Custom lifecycle
 
 Use `NewLifeCycle` when you need a custom stop timeout. Use
-`NewDefaultLifecycle` when you want the same 30 second timeout as the
+`NewDefaultLifecycle` when you want the same 30-second timeout as the
 package-level default, but on your own lifecycle instance.
 
 ```go

--- a/internal/test/rollback.go
+++ b/internal/test/rollback.go
@@ -12,9 +12,9 @@ import (
 // The registered hooks always attempt startup in this order:
 //
 //   - hook 1 starts successfully and stops successfully
-//   - hook 2 fails during start with startErr1
-//   - hook 3 starts successfully and fails during stop with stopErr
-//   - hook 4 fails during start with startErr2
+//   - hook 2 fails during start with hook2StartErr
+//   - hook 3 starts successfully and fails during stop with hook3StopErr
+//   - hook 4 fails during start with hook4StartErr
 //
 // Each hook appends its start and stop activity to the returned slice so callers
 // can assert the exact execution order. The returned pointer remains valid for
@@ -26,8 +26,8 @@ import (
 //   - rolls back only successfully started hooks
 //   - preserves reverse registration order during rollback
 //   - joins startup and rollback errors
-func RegisterRollbackHooks(startErr1, startErr2, stopErr error) *[]string {
-	events := make([]string, 0)
+func RegisterRollbackHooks(hook2StartErr, hook3StopErr, hook4StartErr error) *[]string {
+	events := make([]string, 0, 6)
 
 	signal.Register(signal.Hook{
 		OnStart: func(context.Context) error {
@@ -42,7 +42,7 @@ func RegisterRollbackHooks(startErr1, startErr2, stopErr error) *[]string {
 	signal.Register(signal.Hook{
 		OnStart: func(context.Context) error {
 			events = append(events, "start:2")
-			return startErr1
+			return hook2StartErr
 		},
 		OnStop: func(context.Context) error {
 			events = append(events, "stop:2")
@@ -56,13 +56,13 @@ func RegisterRollbackHooks(startErr1, startErr2, stopErr error) *[]string {
 		},
 		OnStop: func(context.Context) error {
 			events = append(events, "stop:3")
-			return stopErr
+			return hook3StopErr
 		},
 	})
 	signal.Register(signal.Hook{
 		OnStart: func(context.Context) error {
 			events = append(events, "start:4")
-			return startErr2
+			return hook4StartErr
 		},
 		OnStop: func(context.Context) error {
 			events = append(events, "stop:4")

--- a/run_test.go
+++ b/run_test.go
@@ -129,22 +129,22 @@ func TestRunStartError(t *testing.T) {
 }
 
 func TestRunStartRollback(t *testing.T) {
-	startErr1 := errors.New("signal: run start error 1")
-	startErr2 := errors.New("signal: run start error 2")
-	stopErr := errors.New("signal: run stop error")
+	hook2StartErr := errors.New("signal: run hook 2 start error")
+	hook3StopErr := errors.New("signal: run hook 3 stop error")
+	hook4StartErr := errors.New("signal: run hook 4 start error")
 	handlerCalled := false
 
 	signal.SetDefault(signal.NewLifeCycle(time.Minute))
-	events := test.RegisterRollbackHooks(startErr1, startErr2, stopErr)
+	events := test.RegisterRollbackHooks(hook2StartErr, hook3StopErr, hook4StartErr)
 
 	err := signal.Run(t.Context(), func(context.Context) error {
 		handlerCalled = true
 		return nil
 	})
 
-	require.ErrorIs(t, err, startErr1)
-	require.ErrorIs(t, err, startErr2)
-	require.ErrorIs(t, err, stopErr)
+	require.ErrorIs(t, err, hook2StartErr)
+	require.ErrorIs(t, err, hook3StopErr)
+	require.ErrorIs(t, err, hook4StartErr)
 	require.False(t, handlerCalled)
 	require.Equal(t, []string{
 		"start:1",

--- a/serve_test.go
+++ b/serve_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var errServe = errors.New("signal: serve error")
+var errSignal = errors.New("signal: test error")
 
 func TestServeEmpty(t *testing.T) {
 	signal.SetDefault(signal.NewLifeCycle(time.Minute))
@@ -31,7 +31,7 @@ func TestServeStartError(t *testing.T) {
 	signal.SetDefault(signal.NewLifeCycle(time.Minute))
 	signal.Register(signal.Hook{
 		OnStart: func(context.Context) error {
-			return errServe
+			return errSignal
 		},
 	})
 
@@ -39,20 +39,20 @@ func TestServeStartError(t *testing.T) {
 }
 
 func TestServeStartRollback(t *testing.T) {
-	startErr1 := errors.New("signal: serve start error 1")
-	startErr2 := errors.New("signal: serve start error 2")
-	stopErr := errors.New("signal: serve stop error")
+	hook2StartErr := errors.New("signal: serve hook 2 start error")
+	hook3StopErr := errors.New("signal: serve hook 3 stop error")
+	hook4StartErr := errors.New("signal: serve hook 4 start error")
 
 	signal.SetDefault(signal.NewLifeCycle(time.Minute))
-	events := test.RegisterRollbackHooks(startErr1, startErr2, stopErr)
+	events := test.RegisterRollbackHooks(hook2StartErr, hook3StopErr, hook4StartErr)
 
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
 	err := signal.Serve(ctx)
-	require.ErrorIs(t, err, startErr1)
-	require.ErrorIs(t, err, startErr2)
-	require.ErrorIs(t, err, stopErr)
+	require.ErrorIs(t, err, hook2StartErr)
+	require.ErrorIs(t, err, hook3StopErr)
+	require.ErrorIs(t, err, hook4StartErr)
 
 	require.Equal(t, []string{
 		"start:1",
@@ -112,7 +112,7 @@ func TestServeGoError(t *testing.T) {
 	signal.Register(signal.Hook{
 		OnStart: func(ctx context.Context) error {
 			return signal.Go(ctx, time.Minute, func(context.Context) error {
-				return errServe
+				return errSignal
 			})
 		},
 	})
@@ -131,7 +131,7 @@ func TestServeGoTerminated(t *testing.T) {
 		OnStart: func(ctx context.Context) error {
 			return signal.Go(ctx, time.Second, func(context.Context) error {
 				time.Sleep(2 * time.Second)
-				return signal.Terminated(errServe)
+				return signal.Terminated(errSignal)
 			})
 		},
 	})
@@ -143,7 +143,7 @@ func TestServeStopError(t *testing.T) {
 	signal.SetDefault(signal.NewLifeCycle(time.Minute))
 	signal.Register(signal.Hook{
 		OnStop: func(context.Context) error {
-			return errServe
+			return errSignal
 		},
 	})
 
@@ -193,14 +193,14 @@ func TestServeStopTimeoutCause(t *testing.T) {
 }
 
 func TestServeStartContext(t *testing.T) {
-	ch := make(chan bool, 1)
+	canceled := make(chan struct{})
 
 	signal.SetDefault(signal.NewLifeCycle(time.Minute))
 	signal.Register(signal.Hook{
 		OnStart: func(ctx context.Context) error {
 			return signal.Go(ctx, time.Second, func(ctx context.Context) error {
 				<-ctx.Done()
-				ch <- true
+				close(canceled)
 				return nil
 			})
 		},
@@ -212,11 +212,11 @@ func TestServeStartContext(t *testing.T) {
 	}()
 
 	require.NoError(t, signal.Serve(t.Context()))
-	require.True(t, <-ch)
+	<-canceled
 }
 
 func TestServeStartLoopContext(t *testing.T) {
-	ch := make(chan bool, 1)
+	canceled := make(chan struct{})
 
 	signal.SetDefault(signal.NewLifeCycle(time.Minute))
 	signal.Register(signal.Hook{
@@ -225,7 +225,7 @@ func TestServeStartLoopContext(t *testing.T) {
 				for {
 					select {
 					case <-ctx.Done():
-						ch <- true
+						close(canceled)
 						return nil
 					default:
 						time.Sleep(time.Millisecond)
@@ -241,7 +241,7 @@ func TestServeStartLoopContext(t *testing.T) {
 	}()
 
 	require.NoError(t, signal.Serve(t.Context()))
-	require.True(t, <-ch)
+	<-canceled
 }
 
 func TestTimerWithTick(t *testing.T) {
@@ -294,7 +294,7 @@ func TestTimerStartError(t *testing.T) {
 			return signal.Timer(ctx, time.Millisecond, time.Millisecond, signal.Hook{
 				OnStart: func(context.Context) error {
 					time.Sleep(10 * time.Millisecond)
-					return errServe
+					return errSignal
 				},
 			})
 		},
@@ -314,7 +314,7 @@ func TestTimerStartErrorStopsHook(t *testing.T) {
 
 	err := signal.Timer(t.Context(), time.Second, time.Millisecond, signal.Hook{
 		OnStart: func(context.Context) error {
-			return errServe
+			return errSignal
 		},
 		OnStop: func(context.Context) error {
 			stopped = true
@@ -322,7 +322,7 @@ func TestTimerStartErrorStopsHook(t *testing.T) {
 		},
 	})
 
-	require.ErrorIs(t, err, errServe)
+	require.ErrorIs(t, err, errSignal)
 	require.ErrorIs(t, err, stopErr)
 	require.True(t, stopped)
 }
@@ -364,7 +364,7 @@ func TestTimerTickStopError(t *testing.T) {
 		OnStart: func(ctx context.Context) error {
 			return signal.Timer(ctx, time.Millisecond, time.Millisecond, signal.Hook{
 				OnStop: func(context.Context) error {
-					return errServe
+					return errSignal
 				},
 			})
 		},
@@ -389,7 +389,7 @@ func TestTimerTickErrorStopsHook(t *testing.T) {
 		},
 		OnTick: func(context.Context) error {
 			events = append(events, "tick")
-			return errServe
+			return errSignal
 		},
 		OnStop: func(context.Context) error {
 			events = append(events, "stop")
@@ -397,7 +397,7 @@ func TestTimerTickErrorStopsHook(t *testing.T) {
 		},
 	})
 
-	require.ErrorIs(t, err, errServe)
+	require.ErrorIs(t, err, errSignal)
 	require.ErrorIs(t, err, stopErr)
 	require.Equal(t, []string{"start", "tick", "stop"}, events)
 }
@@ -408,7 +408,7 @@ func TestTimerTickError(t *testing.T) {
 		OnStart: func(ctx context.Context) error {
 			return signal.Timer(ctx, time.Millisecond, time.Millisecond, signal.Hook{
 				OnTick: func(context.Context) error {
-					return errServe
+					return errSignal
 				},
 			})
 		},
@@ -440,9 +440,9 @@ func TestTerminatedNil(t *testing.T) {
 }
 
 func TestTerminatedError(t *testing.T) {
-	err := signal.Terminated(errServe)
+	err := signal.Terminated(errSignal)
 
 	require.True(t, signal.IsTerminated(err))
 	require.ErrorIs(t, err, signal.ErrTerminated)
-	require.ErrorIs(t, err, errServe)
+	require.ErrorIs(t, err, errSignal)
 }

--- a/signal.go
+++ b/signal.go
@@ -16,7 +16,7 @@ import (
 // Timer runs hook.Start once, then calls hook.Tick at the given interval until
 // ctx is done.
 //
-// If hook.Start fails, or if ctx is cancelled or a timer hook returns an
+// If hook.Start fails, or if ctx is canceled or a timer hook returns an
 // error, the timer worker calls hook.Stop with a fresh background context
 // bounded by timeout. If that stop context expires and the stop hook returns
 // [context.Cause], the returned error matches [ErrTimeout]. Nil hook callbacks
@@ -24,7 +24,7 @@ import (
 //
 // Timer executes its work through [Go], so a [Terminated] error still triggers
 // [Shutdown]. Because [Go] is a best-effort waiting helper, Timer may return
-// before the timer worker has run hook.Stop when ctx is cancelled or timeout
+// before the timer worker has run hook.Stop when ctx is canceled or timeout
 // elapses first. The interval must be greater than zero.
 func Timer(ctx context.Context, timeout, interval time.Duration, hook Hook) error {
 	if interval <= 0 {
@@ -229,8 +229,8 @@ type Lifecycle struct {
 
 // Register adds a hook to this lifecycle.
 //
-// Note: Lifecycle is not designed to be used concurrently. Register during setup (typically in
-// main), before calling Run or Serve.
+// Note: Lifecycle is not designed to be used concurrently. Register during
+// setup, typically in main, before calling [Lifecycle.Run] or [Lifecycle.Serve].
 func (l *Lifecycle) Register(h Hook) {
 	l.hooks = append(l.hooks, h)
 }
@@ -271,7 +271,7 @@ func (l *Lifecycle) Run(ctx context.Context, h Handler) error {
 // until the notification context is done. If startup fails, Serve still
 // attempts the remaining start hooks, then rolls back successfully started hooks
 // in reverse registration order with a fresh background context bounded by the
-// lifecycle timeout. Shutdown can happen because the parent ctx is cancelled,
+// lifecycle timeout. Shutdown can happen because the parent ctx is canceled,
 // because the process receives SIGINT or SIGTERM, or because [Shutdown]
 // delivers an interrupt to the current process.
 //
@@ -291,7 +291,7 @@ func (l *Lifecycle) Run(ctx context.Context, h Handler) error {
 func (l *Lifecycle) Serve(ctx context.Context) error {
 	signals := []os.Signal{os.Interrupt, syscall.SIGTERM}
 
-	// Reset and ignore signals that were set before, to only capture the ones set after Serve is called.
+	// Reset and ignore prior handlers so Serve only captures signals delivered after it starts.
 	signal.Reset(signals...)
 	signal.Ignore(signals...)
 
@@ -347,8 +347,8 @@ func (l *Lifecycle) stopContext() (context.Context, context.CancelFunc) {
 func (l *Lifecycle) stop(ctx context.Context, hooks []Hook) error {
 	errs := make([]error, 0)
 
-	for _, v := range slices.Backward(hooks) {
-		if err := v.Stop(ctx); err != nil {
+	for _, hook := range slices.Backward(hooks) {
+		if err := hook.Stop(ctx); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/signal_test.go
+++ b/signal_test.go
@@ -47,7 +47,7 @@ func TestHTTPServe(t *testing.T) {
 	require.NoError(t, signal.Serve(t.Context()))
 }
 
-func TestCommandRun(t *testing.T) {
+func TestRunCommand(t *testing.T) {
 	signal.SetDefault(signal.NewLifeCycle(time.Minute))
 	signal.Register(signal.Hook{
 		OnStart: func(ctx context.Context) error {


### PR DESCRIPTION
## What

- Refine lifecycle comments and README wording so timeout and signal-handling prose reads more clearly.
- Clarify rollback test helper names around the hook positions they exercise.
- Replace boolean event channels with signal-only channels and align the command test name with the API-first test naming pattern.

## Why

- Keeps the lifecycle package easier to scan after the style-review pass without changing public behavior or contracts.
- Reduces small bits of mental translation in tests and docs for future reviewers.

## Testing

- `make lint` - passed
- `make specs` - passed
