### PR TITLE
docs(readme): clarify lifecycle hook ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/alexfalkowski/go-signal.svg)](https://pkg.go.dev/github.com/alexfalkowski/go-signal)
 [![Stability: Active](https://masterminds.github.io/stability/active.svg)](https://masterminds.github.io/stability/active.html)
 
-# go-signal
+# 📡 go-signal
 
 A small Go library for coordinating application startup and shutdown hooks
 around OS signals.
 
 The package centers on a `Lifecycle` that runs hooks in three phases:
 
-- start: call each registered `OnStart`
+- start: call each registered `OnStart` in registration order
 - run: execute your handler with `Run` or wait for shutdown with `Serve`
-- stop: call each registered `OnStop`
+- stop: call each registered `OnStop` in reverse registration order
 
 The package-level helpers operate on a process-wide default lifecycle initialized
 with `NewDefaultLifecycle()`, which uses a 30-second stop timeout.
@@ -23,23 +23,27 @@ with `NewDefaultLifecycle()`, which uses a 30-second stop timeout.
 contexts and timer stop hooks. It wraps `sync.ErrTimeout`, which in turn wraps
 `context.DeadlineExceeded`.
 
-## Install
+## 📦 Install
 
 ```sh
 go get github.com/alexfalkowski/go-signal
 ```
 
-## Core API
+## 🧭 Core API
 
-### NewDefaultLifecycle
+### 🧱 NewDefaultLifecycle
 
 Use `NewDefaultLifecycle` when you want the package's standard lifecycle
 configuration without relying on the package-level singleton.
 
-### Register
+### 🧩 Register
 
 Use `Register` during application setup to add hooks to the default lifecycle.
 Hook callbacks are optional, and nil callbacks are treated as no-ops.
+
+> [!IMPORTANT]
+> Register hooks during single-threaded setup before calling `Run` or `Serve`;
+> registration is not concurrent-safe.
 
 ```go
 signal.Register(signal.Hook{
@@ -54,19 +58,19 @@ signal.Register(signal.Hook{
 })
 ```
 
-### Run
+### ▶️ Run
 
 `Run` executes all start hooks, then your handler, then all stop hooks.
 
 - `Run` attempts every start hook, even if an earlier one fails.
 - If startup fails, `Run` rolls back by calling stop hooks for the hooks that
-  started successfully.
+  started successfully in reverse registration order.
 - `Run` executes rollback and stop hooks with a fresh background context bounded
   by the lifecycle timeout.
 - If a rollback or stop hook returns `context.Cause(ctx)` after that stop
   context expires, the returned error matches `signal.ErrTimeout`.
 - After successful startup, `Run` always runs stop hooks, even if the handler
-  fails.
+  fails, in reverse registration order.
 - Startup, handler, and stop-hook errors are combined with `errors.Join`.
 
 ```go
@@ -93,26 +97,27 @@ err := signal.Run(context.Background(), func(context.Context) error {
 })
 ```
 
-### Serve
+### 🛎️ Serve
 
 `Serve` is the long-running variant for processes that should stay alive until
 shutdown is requested.
 
 - It runs start hooks first.
 - If startup fails, it still attempts the remaining start hooks and then rolls
-  back successfully started hooks.
+  back successfully started hooks in reverse registration order.
 - It waits for `SIGINT` or `SIGTERM`, or for the parent context to be canceled.
 - It then runs stop hooks with a fresh background context bounded by the
-  lifecycle timeout.
+  lifecycle timeout in reverse registration order.
 - If a stop hook returns `context.Cause(ctx)` after that stop context expires,
   the returned error matches `signal.ErrTimeout`.
 - During signal takeover, there is a narrow startup handoff window where an
   incoming `SIGINT` or `SIGTERM` may need to be sent again.
 
-`Serve` is intended to be used as the final process-lifetime blocking call. It
-takes ownership of `SIGINT` and `SIGTERM`, does not restore prior signal
-handlers after returning, and callers should normally return from `main` after
-`Serve` returns.
+> [!NOTE]
+> `Serve` is intended to be used as the final process-lifetime blocking call.
+> It takes ownership of `SIGINT` and `SIGTERM`, does not restore prior signal
+> handlers after returning, and callers should normally return from `main` after
+> `Serve` returns.
 
 ```go
 import (
@@ -150,15 +155,15 @@ signal.Register(signal.Hook{
 err := signal.Serve(context.Background())
 ```
 
-### Shutdown
+### 🛑 Shutdown
 
 `Shutdown` sends `os.Interrupt` to the current process through the default
 lifecycle. It is mainly useful for programmatic shutdown, such as from tests or
 from a background goroutine that wants to stop a running `Serve` loop.
 
-## Background helpers
+## 🧰 Background helpers
 
-### Go
+### 🚀 Go
 
 `Go` runs a handler with a timeout-aware wait. It is useful for long-running
 background work that should share a lifecycle context.
@@ -186,7 +191,7 @@ err := signal.Go(context.Background(), 5*time.Second, func(context.Context) erro
 })
 ```
 
-### Timer
+### ⏱️ Timer
 
 `Timer` is a convenience helper for periodic work:
 
@@ -232,11 +237,16 @@ signal.Register(signal.Hook{
 })
 ```
 
-## Custom lifecycle
+## 🛠️ Custom lifecycle
 
 Use `NewLifeCycle` when you need a custom stop timeout. Use
 `NewDefaultLifecycle` when you want the same 30-second timeout as the
 package-level default, but on your own lifecycle instance.
+
+Use `SetDefault` when package-level helpers such as `Register`, `Run`, and
+`Serve` should target a custom lifecycle. Passing `nil` to `SetDefault` restores
+a fresh default lifecycle. `Default` returns the current package-level
+lifecycle.
 
 ```go
 import (
@@ -258,7 +268,26 @@ err := lc.Run(context.Background(), func(context.Context) error {
 })
 ```
 
-## Example
+To use that lifecycle through the package-level helpers:
+
+```go
+signal.SetDefault(lc)
+defer signal.SetDefault(nil)
+
+err := signal.Run(context.Background(), func(context.Context) error {
+    return nil
+})
+```
+
+## 🧪 Example
 
 See [cmd/main.go](cmd/main.go) for a runnable example covering `Serve`, `Go`,
 `Timer`, and termination-triggered shutdown.
+
+```sh
+make run param=terminate
+```
+
+Use `param=start` or `param=timer` for examples that run until interrupted. Use
+`param=terminate` for the example that triggers shutdown from a terminated
+background worker.


### PR DESCRIPTION
## What

- Clarify lifecycle documentation around start order, reverse stop-hook order, rollback, and shutdown.
- Document that `Register` is setup-only and not concurrent-safe.
- Add `Default` and `SetDefault` guidance for package-level helper workflows with custom lifecycle instances.
- Add emoji markers to README headings and include runnable example commands for `cmd/main.go`.

## Why

- The README now matches the public GoDoc and tests for lifecycle ordering and default lifecycle replacement.
- Users can choose hook registration order correctly for dependent resources and avoid dynamic or concurrent registration.
- The manual example is copy-paste-ready instead of requiring readers to infer the `make run param=...` modes.

## Testing

- `go doc .` - passed
- `make specs` - passed on rerun after one timing-sensitive `TestTimerTickError` failure
- `make run param=terminate` - passed
