### PR TITLE
docs(readme): clarify lifecycle contracts and manual usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ shutdown is requested.
   lifecycle timeout in reverse registration order.
 - If a stop hook returns `context.Cause(ctx)` after that stop context expires,
   the returned error matches `signal.ErrTimeout`.
+- Normal shutdown from parent cancellation, `SIGINT`, `SIGTERM`, or `Shutdown()`
+  returns nil unless startup, rollback, or stop hooks return errors.
 - During signal takeover, there is a narrow startup handoff window where an
   incoming `SIGINT` or `SIGTERM` may need to be sent again.
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,7 +13,7 @@ import (
 
 var logger = slog.Default()
 
-const usageMessage = "usage: go run cmd/main.go [start|timer|terminate]"
+const usageMessage = "usage: make run param=start|timer|terminate"
 
 var (
 	errUsage       = errors.New(usageMessage)

--- a/internal/test/rollback.go
+++ b/internal/test/rollback.go
@@ -9,12 +9,19 @@ import (
 // RegisterRollbackHooks registers a fixed set of lifecycle hooks that exercise
 // startup rollback behavior and returns the event log used by those hooks.
 //
+// The hooks are registered on the package-level default lifecycle through
+// signal.Register. Callers should install the desired default lifecycle before
+// calling this helper.
+//
 // The registered hooks always attempt startup in this order:
 //
 //   - hook 1 starts successfully and stops successfully
 //   - hook 2 fails during start with hook2StartErr
 //   - hook 3 starts successfully and fails during stop with hook3StopErr
 //   - hook 4 fails during start with hook4StartErr
+//
+// The rollback and error-join scenario assumes hook2StartErr, hook3StopErr, and
+// hook4StartErr are non-nil.
 //
 // Each hook appends its start and stop activity to the returned slice so callers
 // can assert the exact execution order. The returned pointer remains valid for

--- a/signal.go
+++ b/signal.go
@@ -183,6 +183,9 @@ func SetDefault(l *Lifecycle) {
 }
 
 // Register adds h to the default [Lifecycle].
+//
+// Register during setup, typically in main, before calling [Run] or [Serve].
+// Registration is not designed to be used concurrently.
 func Register(h Hook) {
 	Default().Register(h)
 }
@@ -197,7 +200,8 @@ func Serve(ctx context.Context) error {
 	return Default().Serve(ctx)
 }
 
-// Shutdown calls [Lifecycle.Shutdown] on the default [Lifecycle].
+// Shutdown sends an [os.Interrupt] signal to the current process through the
+// default [Lifecycle].
 func Shutdown() error {
 	return Default().Shutdown()
 }
@@ -279,6 +283,9 @@ func (l *Lifecycle) Run(ctx context.Context, h Handler) error {
 // order with a fresh background context bounded by the lifecycle timeout
 // configured by [NewLifeCycle]. If a stop hook returns [context.Cause] after
 // that context expires, the returned error matches [ErrTimeout].
+//
+// Normal shutdown from parent cancellation, SIGINT, SIGTERM, or [Shutdown]
+// returns nil unless startup, rollback, or stop hooks return errors.
 //
 // Note: Serve is intended to be used as the final process-lifetime blocking
 // call. It takes ownership of SIGINT and SIGTERM, does not restore prior signal


### PR DESCRIPTION
## What

- Document normal `Serve` shutdown return semantics in the README and GoDoc.
- Make package-level `Register` and `Shutdown` comments self-contained about setup safety and signal delivery.
- Align the manual example usage text with the documented `make run param=...` entrypoint and document rollback helper preconditions.

## Why

- These docs close gaps where public API consumers and maintainers could misread lifecycle shutdown behavior, default lifecycle mutation, or the manual command interface.
- The changes keep behavior unchanged while making the existing contracts visible at the entrypoints users and maintainers are likely to read.

## Testing

- `make lint` - passed
- `make specs` - passed
