### PR TITLE
docs(readme): clarify lifecycle edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ contexts and timer stop hooks. It wraps `sync.ErrTimeout`, which in turn wraps
 
 ## 📦 Install
 
+Use the Go toolchain version declared in [go.mod](go.mod).
+
 ```sh
 go get github.com/alexfalkowski/go-signal
 ```
@@ -69,9 +71,11 @@ signal.Register(signal.Hook{
   by the lifecycle timeout.
 - If a rollback or stop hook returns `context.Cause(ctx)` after that stop
   context expires, the returned error matches `signal.ErrTimeout`.
-- After successful startup, `Run` always runs stop hooks, even if the handler
-  fails, in reverse registration order.
+- After successful startup, `Run` always runs stop hooks when the handler
+  returns, even if it returns an error, in reverse registration order.
 - Startup, handler, and stop-hook errors are combined with `errors.Join`.
+- `Run` does not recover panics from hooks or the handler, so panic recovery
+  should live in application code when cleanup must be guaranteed.
 
 ```go
 import (
@@ -175,6 +179,8 @@ background work that should share a lifecycle context.
 
 - `Go` only reports errors observed before its timeout or parent context
   cancellation.
+- If the parent context is already done or the timeout is not positive, `Go`
+  returns nil without starting the handler.
 - If the worker keeps running after that waiting window, later non-terminated
   errors are not returned to the caller.
 - If the handler returns an error marked with `signal.Terminated(err)`, `Go`
@@ -210,7 +216,10 @@ err := signal.Go(context.Background(), 5*time.Second, func(context.Context) erro
 
 Because `Timer` executes through `Go`, it uses best-effort waiting semantics:
 when the parent context is canceled or the wait timeout elapses first, `Timer`
-may return before the timer worker has run `hook.OnStop`.
+may return before the timer worker has run `hook.OnStop`, and late
+non-terminated hook errors are not returned to the caller. With a valid
+interval, if the parent context is already done or the timeout is not positive,
+the timer worker does not start.
 
 The interval must be greater than zero or `Timer` returns `ErrInvalidInterval`.
 
@@ -247,6 +256,10 @@ signal.Register(signal.Hook{
 Use `NewLifeCycle` when you need a custom stop timeout. Use
 `NewDefaultLifecycle` when you want the same 30-second timeout as the
 package-level default, but on your own lifecycle instance.
+
+Use a positive custom stop timeout. A zero or negative timeout creates an
+already-expired stop context, so stop hooks that observe the context may return
+`signal.ErrTimeout` immediately.
 
 Use `SetDefault` when package-level helpers such as `Register`, `Run`, and
 `Serve` should target a custom lifecycle. Passing `nil` to `SetDefault` restores
@@ -287,10 +300,12 @@ err := signal.Run(context.Background(), func(context.Context) error {
 ## 🧪 Example
 
 See [cmd/main.go](cmd/main.go) for a runnable example covering `Serve`, `Go`,
-`Timer`, and termination-triggered shutdown.
+`Timer`, and termination-triggered shutdown. It is a manual `make run` example,
+not an installed or production CLI.
 
 Initialize the shared `bin` tooling first when running Make targets from a
-fresh clone:
+fresh clone. The submodule uses GitHub SSH, so SSH access must be configured
+before this step:
 
 ```sh
 git submodule sync

--- a/signal.go
+++ b/signal.go
@@ -16,6 +16,9 @@ import (
 // Timer runs hook.Start once, then calls hook.Tick at the given interval until
 // ctx is done.
 //
+// With a valid interval, if ctx is already done on entry or timeout is not
+// positive, Timer returns nil without starting the timer worker.
+//
 // If hook.Start fails, or if ctx is canceled or a timer hook returns an
 // error, the timer worker calls hook.Stop with a fresh background context
 // bounded by timeout. If that stop context expires and the stop hook returns
@@ -25,7 +28,8 @@ import (
 // Timer executes its work through [Go], so a [Terminated] error still triggers
 // [Shutdown]. Because [Go] is a best-effort waiting helper, Timer may return
 // before the timer worker has run hook.Stop when ctx is canceled or timeout
-// elapses first. The interval must be greater than zero.
+// elapses first, and late non-terminated hook errors are not returned to the
+// caller. The interval must be greater than zero.
 func Timer(ctx context.Context, timeout, interval time.Duration, hook Hook) error {
 	if interval <= 0 {
 		return fmt.Errorf("%w: %s", ErrInvalidInterval, interval)
@@ -91,6 +95,11 @@ func IsTerminated(err error) bool {
 // Go is a best-effort waiting helper. If timeout elapses or ctx is done first,
 // Go returns nil immediately while handler may continue running in the
 // background.
+//
+// If ctx is already done on entry or timeout is not positive, Go returns nil
+// without invoking handler.
+//
+// If handler is nil, Go returns [sync.ErrNoOnRunProvided].
 //
 // If handler returns an error marked with [ErrTerminated], Go triggers
 // [Shutdown] before returning the error. If that terminated error arrives after
@@ -216,7 +225,10 @@ func NewDefaultLifecycle() *Lifecycle {
 // timeout.
 //
 // The stop timeout is used by [Lifecycle.Run] and [Lifecycle.Serve] when
-// running stop hooks during rollback and shutdown.
+// running stop hooks during rollback and shutdown. It is passed directly to
+// [context.WithTimeoutCause], so a non-positive timeout creates an
+// already-expired stop context. Use a positive duration when stop hooks need
+// time to clean up.
 func NewLifeCycle(timeout time.Duration) *Lifecycle {
 	return &Lifecycle{hooks: make([]Hook, 0), timeout: timeout}
 }
@@ -249,6 +261,9 @@ func (l *Lifecycle) Register(h Hook) {
 // hook in reverse registration order with the same kind of fresh shutdown
 // context. If a stop hook returns [context.Cause] after that context expires,
 // the returned error matches [ErrTimeout].
+//
+// Run requires a non-nil handler. It does not recover panics from start hooks,
+// the handler, or stop hooks; stop hooks run after the handler returns.
 //
 // Startup, handler, and stop-hook errors are combined with [errors.Join].
 func (l *Lifecycle) Run(ctx context.Context, h Handler) error {


### PR DESCRIPTION
## What

- Clarify lifecycle documentation for timeout, cancellation, panic, and late-error edge cases in README and GoDoc.
- Document Go toolchain, manual example, and SSH submodule setup expectations for first-use workflows.

## Why

- These contracts affect package consumers choosing timeout values, relying on cleanup hooks, or running the documented example from a fresh clone.
- Making the boundaries explicit reduces silent no-op and cleanup-assumption risk without changing runtime behavior.

## Testing

- `go doc -all .` - passed
- `git diff --check` - passed
- `make lint` - passed with the existing gomodguard deprecation warning
- `make specs` - passed, 39 tests
- `make run param=terminate` - passed
