### PR TITLE
docs(readme): clarify lifecycle edge cases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+include bin/build/make/help.mak
 include bin/build/make/go.mak
 include bin/build/make/git.mak
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The package-level helpers operate on a process-wide default lifecycle initialize
 with `NewDefaultLifecycle()`, which uses a 30-second stop timeout.
 
 `signal.ErrTimeout` is the package-owned timeout cause used for lifecycle stop
-contexts and timer stop hooks. It wraps `sync.ErrTimeout`, which in turn wraps
-`context.DeadlineExceeded`.
+contexts and timer stop hooks. It wraps `github.com/alexfalkowski/go-sync`'s
+`sync.ErrTimeout`, which in turn wraps `context.DeadlineExceeded`.
 
 ## 📦 Install
 

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,37 @@
+package signal_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/alexfalkowski/go-signal"
+)
+
+func Example() {
+	lifecycle := signal.NewLifeCycle(time.Second)
+	events := make([]string, 0, 3)
+
+	lifecycle.Register(signal.Hook{
+		OnStart: func(context.Context) error {
+			events = append(events, "start")
+			return nil
+		},
+		OnStop: func(context.Context) error {
+			events = append(events, "stop")
+			return nil
+		},
+	})
+
+	err := lifecycle.Run(context.Background(), func(context.Context) error {
+		events = append(events, "run")
+		return nil
+	})
+
+	fmt.Println(err)
+	fmt.Println(events)
+
+	// Output:
+	// <nil>
+	// [start run stop]
+}

--- a/internal/test/rollback.go
+++ b/internal/test/rollback.go
@@ -23,9 +23,9 @@ import (
 // The rollback and error-join scenario assumes hook2StartErr, hook3StopErr, and
 // hook4StartErr are non-nil.
 //
-// Each hook appends its start and stop activity to the returned slice so callers
-// can assert the exact execution order. The returned pointer remains valid for
-// the lifetime of the test because the closures capture the underlying slice.
+// Each hook appends its start and stop activity to the captured events slice, so
+// callers can inspect the returned pointer after running the lifecycle and
+// assert the exact execution order.
 //
 // This helper is intended for tests that need to verify that startup:
 //

--- a/signal.go
+++ b/signal.go
@@ -29,7 +29,8 @@ import (
 // [Shutdown]. Because [Go] is a best-effort waiting helper, Timer may return
 // before the timer worker has run hook.Stop when ctx is canceled or timeout
 // elapses first, and late non-terminated hook errors are not returned to the
-// caller. The interval must be greater than zero.
+// caller. The interval must be greater than zero or Timer returns
+// [ErrInvalidInterval].
 func Timer(ctx context.Context, timeout, interval time.Duration, hook Hook) error {
 	if interval <= 0 {
 		return fmt.Errorf("%w: %s", ErrInvalidInterval, interval)
@@ -62,8 +63,8 @@ var ErrInvalidInterval = errors.New("signal: invalid interval")
 
 // ErrTimeout is the timeout cause used by derived stop contexts in this package.
 //
-// It wraps [sync.ErrTimeout], so [errors.Is] also matches
-// [context.DeadlineExceeded].
+// It wraps [sync.ErrTimeout] from github.com/alexfalkowski/go-sync, so
+// [errors.Is] also matches [context.DeadlineExceeded].
 var ErrTimeout = fmt.Errorf("signal: %w", sync.ErrTimeout)
 
 // ErrTerminated marks an error as requesting process shutdown.
@@ -238,6 +239,9 @@ func NewLifeCycle(timeout time.Duration) *Lifecycle {
 // A lifecycle is usually configured during application setup by calling
 // [Lifecycle.Register], then executed through [Lifecycle.Run] or
 // [Lifecycle.Serve].
+//
+// Use [NewLifeCycle] or [NewDefaultLifecycle] to construct a lifecycle. The zero
+// value has a zero stop timeout, so stop contexts are already expired.
 type Lifecycle struct {
 	hooks   []Hook
 	timeout time.Duration
@@ -262,8 +266,9 @@ func (l *Lifecycle) Register(h Hook) {
 // context. If a stop hook returns [context.Cause] after that context expires,
 // the returned error matches [ErrTimeout].
 //
-// Run requires a non-nil handler. It does not recover panics from start hooks,
-// the handler, or stop hooks; stop hooks run after the handler returns.
+// Run requires a non-nil handler; passing nil panics when Run invokes it. It
+// does not recover panics from start hooks, the handler, or stop hooks; stop
+// hooks run after the handler returns.
 //
 // Startup, handler, and stop-hook errors are combined with [errors.Join].
 func (l *Lifecycle) Run(ctx context.Context, h Handler) error {


### PR DESCRIPTION
## What

- Added an executable package example that shows a local lifecycle registering hooks and running them in start, run, stop order.
- Clarified lifecycle documentation for timeout sentinel provenance, timer invalid intervals, zero-value lifecycle timeout behavior, and nil Run handlers.
- Added the shared help make fragment before the Go and Git fragments so both `make` and `make help` expose the command catalog.
- Corrected the internal rollback helper comment so it describes the captured event log accurately.

## Why

- Package consumers can now learn the primary lifecycle call shape from executable GoDoc output instead of relying on README-only snippets.
- The public comments now document edge-case contracts that affect cleanup timing, error matching, and panic expectations.
- Maintainers get a working local command catalog and a clearer test helper contract.

## Testing

- `make -n` - passed; confirmed the no-argument target resolves to help.
- `make help` - passed; confirmed the command catalog renders.
- `git diff --check` - passed; confirmed no whitespace errors.
- `make lint` - passed; reported the existing `gomodguard` deprecation warning and 0 issues.
- `make specs` - passed; ran 40 tests including the new executable `Example`.

AI-assisted-by: [Codex](https://openai.com/codex/)
